### PR TITLE
fix: Change Execution mode local for newrelic

### DIFF
--- a/terraform/newrelic/main.tf
+++ b/terraform/newrelic/main.tf
@@ -14,6 +14,14 @@ terraform {
   }
 }
 
+variable "newrelic_accountid" {
+  type = string  
+}
+
+variable "newrelic_key" {
+  type = string  
+}
+
 provider "newrelic" {
   account_id = var.newrelic_accountid # Your New Relic account ID
   api_key    = var.newrelic_key       # Your New Relic user key


### PR DESCRIPTION
app.terraform.io の morihaya-infra-newrelic
Workspaces の Execution Mode を
Remote -> Local とした

理由は .envrc からの環境変数渡しがRemoteだとエラーになるため
