### PR TITLE
feat: IAMユーザへのパスワードポリシーとMFA必須化を追加

### DIFF
--- a/terraform/aws/root/iam_mfa_policy.tf
+++ b/terraform/aws/root/iam_mfa_policy.tf
@@ -1,0 +1,86 @@
+# IAM Policy: Enforce MFA
+# MFA未設定のユーザがMFAデバイスの設定のみ行えるよう許可し、他の操作はすべて拒否する
+resource "aws_iam_policy" "enforce_mfa" {
+  name        = "EnforceMFA"
+  description = "Deny all actions except MFA self-management when MFA is not authenticated"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # MFA設定に必要な操作のみ許可（MFA未認証でも可）
+      {
+        Sid    = "AllowViewAccountInfo"
+        Effect = "Allow"
+        Action = [
+          "iam:GetAccountPasswordPolicy",
+          "iam:ListVirtualMFADevices"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowManageOwnMFA"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateVirtualMFADevice",
+          "iam:EnableMFADevice",
+          "iam:GetUser",
+          "iam:ListMFADevices",
+          "iam:ResyncMFADevice"
+        ]
+        Resource = [
+          "arn:aws:iam::*:mfa/$${aws:username}",
+          "arn:aws:iam::*:user/$${aws:username}"
+        ]
+      },
+      # MFA認証済みの場合のみ自分のMFAデバイスの削除を許可
+      {
+        Sid    = "AllowDeactivateOwnMFAWithMFA"
+        Effect = "Allow"
+        Action = [
+          "iam:DeactivateMFADevice",
+          "iam:DeleteVirtualMFADevice"
+        ]
+        Resource = [
+          "arn:aws:iam::*:mfa/$${aws:username}",
+          "arn:aws:iam::*:user/$${aws:username}"
+        ]
+        Condition = {
+          Bool = {
+            "aws:MultiFactorAuthPresent" = "true"
+          }
+        }
+      },
+      # MFA未認証の場合、上記以外のすべての操作を拒否
+      {
+        Sid    = "DenyAllExceptMFAManagementWithoutMFA"
+        Effect = "Deny"
+        NotAction = [
+          "iam:CreateVirtualMFADevice",
+          "iam:EnableMFADevice",
+          "iam:GetUser",
+          "iam:GetAccountPasswordPolicy",
+          "iam:ListMFADevices",
+          "iam:ListVirtualMFADevices",
+          "iam:ResyncMFADevice",
+          "sts:GetSessionToken"
+        ]
+        Resource = "*"
+        Condition = {
+          BoolIfExists = {
+            "aws:MultiFactorAuthPresent" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# すべてのIAMユーザに適用するグループ
+resource "aws_iam_group" "require_mfa" {
+  name = "RequireMFA"
+}
+
+resource "aws_iam_group_policy_attachment" "require_mfa" {
+  group      = aws_iam_group.require_mfa.name
+  policy_arn = aws_iam_policy.enforce_mfa.arn
+}

--- a/terraform/aws/root/iam_password_policy.tf
+++ b/terraform/aws/root/iam_password_policy.tf
@@ -1,0 +1,12 @@
+# IAM Account Password Policy
+resource "aws_iam_account_password_policy" "this" {
+  minimum_password_length        = 16
+  require_uppercase_characters   = true
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_symbols                = true
+  allow_users_to_change_password = true
+  max_password_age               = 90
+  password_reuse_prevention      = 10
+  hard_expiry                    = false
+}

--- a/terraform/aws/root/outputs.tf
+++ b/terraform/aws/root/outputs.tf
@@ -1,0 +1,14 @@
+output "enforce_mfa_policy_arn" {
+  description = "ARN of the EnforceMFA IAM policy"
+  value       = aws_iam_policy.enforce_mfa.arn
+}
+
+output "require_mfa_group_name" {
+  description = "Name of the RequireMFA IAM group"
+  value       = aws_iam_group.require_mfa.name
+}
+
+output "require_mfa_group_arn" {
+  description = "ARN of the RequireMFA IAM group"
+  value       = aws_iam_group.require_mfa.arn
+}


### PR DESCRIPTION
- aws_iam_account_password_policy: 強力なパスワードポリシーをアカウント全体に適用
  - 最低16文字、大文字・小文字・数字・記号すべて必須
  - 90日でパスワード期限切れ、過去10世代の再利用禁止
- EnforceMFA IAMポリシー: MFA未認証時は自己MFA設定以外の操作をすべてDeny
- RequireMFA IAMグループ: EnforceMFAポリシーをアタッチ
- outputs.tf: 他ワークスペースからdata参照できるようARN等を出力