### PR TITLE
chore: common-r53 の TTL を 297 に統一

### DIFF
--- a/terraform/aws/common-r53/home.morihaya.tech.tf
+++ b/terraform/aws/common-r53/home.morihaya.tech.tf
@@ -37,6 +37,6 @@ module "home_records" {
   zone_id = data.aws_route53_zone.morihaya_tech.zone_id
   name    = each.value.name
   type    = lookup(each.value, "type", "A")
-  ttl     = lookup(each.value, "ttl", 300)
+  ttl     = lookup(each.value, "ttl", 297)
   records = each.value.records
 }

--- a/terraform/aws/common-r53/modules/route53_record/variables.tf
+++ b/terraform/aws/common-r53/modules/route53_record/variables.tf
@@ -17,7 +17,7 @@ variable "type" {
 variable "ttl" {
   description = "TTL in seconds"
   type        = number
-  default     = 300
+  default     = 297
 }
 
 variable "records" {

--- a/terraform/aws/common-r53/r53.tf
+++ b/terraform/aws/common-r53/r53.tf
@@ -11,12 +11,12 @@ locals {
     }
     example3 = {
       name    = "example3.morihaya.tech"
-      ttl     = 299
+      ttl     = 297
       records = ["192.0.2.4"]
     }
     haruhhkko-minecraft-server = {
       name    = "haruhhkko-minecraft-server.morihaya.tech"
-      ttl     = 299
+      ttl     = 297
       records = ["140.238.51.204"]
     }
   }
@@ -29,6 +29,6 @@ module "records" {
   zone_id = data.aws_route53_zone.morihaya_tech.zone_id
   name    = each.value.name
   type    = lookup(each.value, "type", "A")
-  ttl     = lookup(each.value, "ttl", 300)
+  ttl     = lookup(each.value, "ttl", 297)
   records = each.value.records
 }


### PR DESCRIPTION
概要: common-r53 配下の TTL 設定をすべて 297 に統一しました。\n\n変更内容:\n- r53.tf の個別 TTL 値を 297 に変更\n- r53.tf の TTL デフォルト値を 297 に変更\n- home.morihaya.tech.tf の TTL デフォルト値を 297 に変更\n- modules/route53_record/variables.tf の ttl デフォルト値を 297 に変更\n\n補足:\n- 既存の .terraform.lock.hcl 変更はこのPRに含めていません。