### PR TITLE
chore(r53): 実体の無い ceph.home.morihaya.tech を削除

### DIFF
--- a/terraform/aws/common-r53/home.morihaya.tech.tf
+++ b/terraform/aws/common-r53/home.morihaya.tech.tf
@@ -7,10 +7,6 @@ locals {
       name    = "pve.home.morihaya.tech"
       records = ["192.168.1.6"] # 実IPは 192.168.1.2 だがTraefik経由でアクセス
     }
-    ceph = {
-      name    = "ceph.home.morihaya.tech"
-      records = ["192.168.1.3"]
-    }
     dns = {
       name    = "dns.home.morihaya.tech"
       records = ["192.168.1.6"] # 実IPは 192.168.1.4 だがTraefik経由でアクセス


### PR DESCRIPTION
## 何を消すか

`ceph.home.morihaya.tech` → `192.168.1.3` の A レコードを削除する。

## なぜ

Proxmox クラスタを調査した際 ([#64](https://github.com/morihaya/morihaya-infra/pull/64))、このホストが**実在しない**ことが分かった。

- `192.168.1.3` はクラスタのどのノードでもゲストでもない (`pve`=.2 / `pve2`=.10 / `pve3`=.11)
- Ceph も構成されていない。`/etc/pve/storage.cfg` は `local` (dir) と `local-lvm` (lvmthin) のみ

`home.morihaya.tech` は公開 Route53 ゾーンなので、実体の無いレコードで内部アドレスを晒しているだけの状態だった。

```console
$ dig +short ceph.home.morihaya.tech @1.1.1.1
192.168.1.3
```

## 補足

このゾーンの他のレコードも内部 IP (RFC1918) を公開 DNS に載せている。RFC1918 は経路を持たないため外部から到達はできず偵察情報としての価値しかないが、実体の無いものだけは消しておく。残りは Traefik 経由のアクセスに実際に使われているため維持する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)