### PR TITLE
feat(ci): マージ後に HCP Terraform の run リンクを PR へコメントする

### DIFF
--- a/.github/workflows/hcp-tf-comment.yml
+++ b/.github/workflows/hcp-tf-comment.yml
@@ -1,0 +1,159 @@
+name: HCP Terraform Run Comment
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: read
+
+# HCP Terraform は run の状態を legacy commit status API で通知する
+#   context     : Terraform Cloud/morihaya/morihaya-infra-homelab
+#   target_url  : https://app.terraform.io/app/morihaya/.../runs/run-xxxx
+#   description : Terraform plan: 0 to add, 3 to change, 0 to destroy.
+# これを拾い、マージ元の PR へ run へのリンクをコメントする。
+#
+# ワークスペースは auto-apply が無効なため、マージしただけでは適用されない。
+# 承認を忘れるとワークスペースがロックされ、後続の run が滞留する
+# (実際に 2026-06-21 から 1 ヶ月以上滞留した)。その再発防止が目的。
+on:
+  status:
+
+# 複数ワークスペースが同時に status を投げると workflow が並行実行され、
+# どちらも「既存コメント無し」と判定して二重投稿しうる。
+# コミット単位で直列化する (cancel-in-progress は付けない。
+# 後から来た status ほど新しい情報を持つため、全て処理させる)。
+concurrency:
+  group: hcp-tf-comment-${{ github.event.sha }}
+  cancel-in-progress: false
+
+jobs:
+  comment-run-url:
+    name: Comment HCP Terraform run URL
+    runs-on: ubuntu-latest
+    # - HCP Terraform 以外の status (CodeQL 等) を除外
+    # - pending は description が "Terraform plan pending" で情報が無いため、
+    #   plan 結果が確定してから 1 回だけコメントする
+    # - PR ブランチへの speculative plan も status を投げるので、
+    #   main 上のコミットに限定する
+    if: >-
+      startsWith(github.event.context, 'Terraform Cloud/')
+      && github.event.state != 'pending'
+      && contains(github.event.branches.*.name, 'main')
+
+    steps:
+      - name: Find merged PR for this commit
+        id: find-pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMIT_SHA: ${{ github.event.sha }}
+        with:
+          script: |
+            const sha = process.env.COMMIT_SHA;
+            core.info(`Looking for merged PR associated with commit ${sha}`);
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+            });
+
+            // merge commit / squash merge の双方に対応
+            const mergedPr = prs.find(pr => pr.merged_at && pr.merge_commit_sha === sha);
+
+            if (!mergedPr) {
+              core.info('No merged PR found for this commit. Skipping.');
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            core.info(`Found merged PR #${mergedPr.number}: ${mergedPr.title}`);
+            core.setOutput('found', 'true');
+            core.setOutput('pr_number', mergedPr.number.toString());
+
+      - name: Collect HCP Terraform run URLs and upsert comment
+        if: steps.find-pr.outputs.found == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
+          COMMIT_SHA: ${{ github.event.sha }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const sha = process.env.COMMIT_SHA;
+            const marker = '<!-- hcp-terraform-runs -->';
+
+            const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+            });
+
+            const hcpStatuses = combined.statuses.filter(s =>
+              s.context.startsWith('Terraform Cloud/')
+              && s.target_url
+              && s.target_url.startsWith('https://app.terraform.io/')
+            );
+
+            if (hcpStatuses.length === 0) {
+              core.info('No HCP Terraform statuses with target_url found.');
+              return;
+            }
+
+            // target_url で重複排除
+            const seen = new Set();
+            const unique = hcpStatuses.filter(s => {
+              if (seen.has(s.target_url)) return false;
+              seen.add(s.target_url);
+              return true;
+            });
+
+            const rows = unique.map(s => {
+              // "Terraform Cloud/morihaya/morihaya-infra-homelab" → "morihaya-infra-homelab"
+              const name = s.context.replace(/^Terraform Cloud\/[^/]+\//, '');
+              return `| [${name}](${s.target_url}) | ${s.description || ''} |`;
+            });
+
+            const body = [
+              marker,
+              '## HCP Terraform Runs',
+              '',
+              `> マージコミット: \`${sha.substring(0, 7)}\``,
+              '',
+              '| Run | Description |',
+              '|-----|-------------|',
+              ...rows,
+              '',
+              '**auto-apply は無効です。Run リンクから HCP Terraform を開き、Confirm & Apply を実行してください。**',
+              '承認しないままだとワークスペースがロックされ、後続の run が滞留します。',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c =>
+              c.body && c.body.includes(marker)
+              && c.user && c.user.login === 'github-actions[bot]'
+            );
+
+            if (existing) {
+              core.info(`Updating existing comment #${existing.id}`);
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              core.info('Creating new comment');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+            }
+
+            core.info(`Posted ${unique.length} HCP Terraform run link(s) to PR #${prNumber}`);

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ This repository contains infrastructure definitions for managing multiple cloud 
   [.terraform-version](.terraform-version) (tfenv/mise compatible)
 - CI runs `terraform fmt -check`, `terraform validate`, `tflint`, and
   `actionlint`; GitHub Actions are pinned to commit SHAs (via pinact)
+- After a PR is merged,
+  [hcp-tf-comment.yml](.github/workflows/hcp-tf-comment.yml) posts the resulting
+  HCP Terraform run links back to that PR. The workspaces have `auto-apply`
+  disabled, so merging alone changes nothing — an unconfirmed run leaves the
+  workspace locked and queues everything behind it
 
 ## 🔑 Local HCP Terraform credentials
 


### PR DESCRIPTION
## 背景

ワークスペースは `auto-apply` が無効なので、**PR をマージしただけでは適用されない**。承認を忘れると run が `planned` のまま残ってワークスペースをロックし、後続の run が全て滞留する。

実際にこれが起きていた。2026-06-21 の Dependabot run が確認待ちのまま 1 ヶ月以上放置され、その裏で #61 の apply がキューに詰まったまま実行されていなかった。最後に成功した apply は 2026-01-14 で、[#64](https://github.com/morihaya/morihaya-infra/pull/64) で見つかった IaC と実機の乖離はこれが根本原因だった。

再発防止として、マージ後に生成された run へのリンクを元 PR へコメントする。

## 動作

HCP Terraform は run の状態を **legacy commit status API** で通知している。実データで確認済み。

```console
$ gh api repos/morihaya/morihaya-infra/commits/3da29f1/status
{
  "context": "Terraform Cloud/morihaya/morihaya-infra-homelab",
  "state": "success",
  "target_url": "https://app.terraform.io/app/morihaya/morihaya-infra-homelab/runs/run-eaJQieS4jFXMCsEj",
  "description": "Terraform plan: 0 to add, 3 to change, 0 to destroy."
}
```

`on: status` でこれを拾い、`listPullRequestsAssociatedWithCommit` でマージ元 PR を特定して、run のリンクと plan サマリの表をコメントする。マーカーコメントによる upsert なので、複数回発火しても 1 つのコメントが更新されるだけ。

## 参照元からの変更点

`aeon-smart-technology-emu/sre-gha-templates` の `hcp-tf-comment.yml` を元にしたが、**あちらは private org の reusable workflow で公開リポジトリからは呼び出せない**ため、ロジックをインライン化した。あわせて以下を変更している。

| 変更 | 理由 |
|---|---|
| `concurrency` を追加 | 複数ワークスペースが同時に status を投げると workflow が並行実行され、どちらも「既存コメント無し」と判定して**二重投稿しうる**。コミット単位で直列化する |
| `context.sha` → `github.event.sha` | `status` イベントの `GITHUB_SHA` はデフォルトブランチの HEAD であり、status 対象のコミットとは限らない |
| SHA を env 経由で渡す | スクリプトへの直接展開を避ける |
| job の `if` でフィルタ | 参照元は caller 側でフィルタする前提だった。`state != 'pending'` (description が確定してから) かつ main 上のコミットに限定 (PR ブランチへの speculative plan も status を投げるため) |

## 検証

- `actionlint` パス
- `pinact run --check` パス (`actions/github-script` を v9.0.0 の commit SHA で pin)

> [!NOTE]
> `on: status` の workflow は**デフォルトブランチのものが実行される**ため、この PR 自体では発火しない。マージ後の次の PR から有効になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)