### PR TITLE
ci(ansible): ansible-lint を CI に追加

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -21,6 +21,13 @@ jobs:
     name: Ansible Lint
     runs-on: ubuntu-latest
 
+    env:
+      # ansible-galaxy は runner にプリインストール済みの collection を見つけて
+      # "Nothing to do" で終わる一方、ansible-lint は ansible-compat によって
+      # 隔離された環境で動くためそれを解決できず syntax-check で落ちる。
+      # 導入先と探索先を同じパスに固定して食い違いを防ぐ。
+      ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/.ansible/collections
+
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -21,23 +21,21 @@ jobs:
     name: Ansible Lint
     runs-on: ubuntu-latest
 
-    env:
-      # ansible-galaxy は runner にプリインストール済みの collection を見つけて
-      # "Nothing to do" で終わる一方、ansible-lint は ansible-compat によって
-      # 隔離された環境で動くためそれを解決できず syntax-check で落ちる。
-      # 導入先と探索先を同じパスに固定して食い違いを防ぐ。
-      ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/.ansible/collections
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # アクションの requirements_file 入力は使わない。ansible-galaxy に
+      # --force を渡せず、runner にプリインストール済みの collection を見て
+      # "Nothing to do" で終わってしまう。その場所は ansible-lint の探索対象
+      # 外なので ansible.posix.authorized_key が解決できず syntax-check で
+      # 落ちる。~/.ansible/collections へ強制的に導入して回避する。
+      - name: Install collection dependencies
+        working-directory: ansible
+        run: ansible-galaxy collection install -r requirements.yml --force
+
       # working_directory を ansible にすることで ansible.cfg が読まれる。
-      # requirements_file は working_directory からの相対パス。
-      # ansible.posix を入れておかないと FQCN モジュールを解決できず、
-      # 検査の精度が落ちる。
       - name: Run ansible-lint
         uses: ansible/ansible-lint@262624cd0ab22a4221293216856c59671ce7aa5e # v26.6.0
         with:
           working_directory: ansible
-          requirements_file: requirements.yml

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,36 @@
+name: Ansible Lint
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'ansible/**'
+      - '.github/workflows/ansible-lint.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'ansible/**'
+      - '.github/workflows/ansible-lint.yml'
+
+jobs:
+  ansible-lint:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # working_directory を ansible にすることで ansible.cfg が読まれる。
+      # requirements_file は working_directory からの相対パス。
+      # ansible.posix を入れておかないと FQCN モジュールを解決できず、
+      # 検査の精度が落ちる。
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@262624cd0ab22a4221293216856c59671ce7aa5e # v26.6.0
+        with:
+          working_directory: ansible
+          requirements_file: requirements.yml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Terraform Format Check](https://github.com/morihaya/morihaya-infra/actions/workflows/terraform-fmt.yml/badge.svg)](https://github.com/morihaya/morihaya-infra/actions/workflows/terraform-fmt.yml)
 [![Terraform Validate](https://github.com/morihaya/morihaya-infra/actions/workflows/terraform-validate.yml/badge.svg)](https://github.com/morihaya/morihaya-infra/actions/workflows/terraform-validate.yml)
 [![Actionlint](https://github.com/morihaya/morihaya-infra/actions/workflows/actionlint.yml/badge.svg)](https://github.com/morihaya/morihaya-infra/actions/workflows/actionlint.yml)
+[![Ansible Lint](https://github.com/morihaya/morihaya-infra/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/morihaya/morihaya-infra/actions/workflows/ansible-lint.yml)
 [![Dependabot Updates](https://github.com/morihaya/morihaya-infra/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/morihaya/morihaya-infra/actions/workflows/dependabot/dependabot-updates)
 [![CodeQL](https://github.com/morihaya/morihaya-infra/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/morihaya/morihaya-infra/actions/workflows/github-code-scanning/codeql)
 
@@ -31,8 +32,8 @@ This repository contains infrastructure definitions for managing multiple cloud 
 │   └── tailscale/      # Tailscale VPN ACLs and DNS
 │
 └── ansible/            # Configuration Management
-    ├── inventories/    # Host definitions
-    └── roles/          # Reusable roles (common, docker-compose, postgres)
+    ├── inventories/    # Host definitions (plaintext; see ansible/README.md)
+    └── roles/          # Reusable roles (common)
 ```
 
 ## 🛠️ Terraform Configurations
@@ -62,8 +63,8 @@ This repository contains infrastructure definitions for managing multiple cloud 
 - Provider versions are pinned and `.terraform.lock.hcl` files are committed
 - The Terraform CLI version for local development is pinned in
   [.terraform-version](.terraform-version) (tfenv/mise compatible)
-- CI runs `terraform fmt -check`, `terraform validate`, `tflint`, and
-  `actionlint`; GitHub Actions are pinned to commit SHAs (via pinact)
+- CI runs `terraform fmt -check`, `terraform validate`, `tflint`, `ansible-lint`,
+  and `actionlint`; GitHub Actions are pinned to commit SHAs (via pinact)
 - After a PR is merged,
   [hcp-tf-comment.yml](.github/workflows/hcp-tf-comment.yml) posts the resulting
   HCP Terraform run links back to that PR. The workspaces have `auto-apply`


### PR DESCRIPTION
## 背景

[#66](https://github.com/morihaya/morihaya-infra/pull/66) のインベントリ再構築で判明したとおり、`ansible/` 配下は前の RHEL 系環境向けのまま長期間放置されていた。

- `wheel` グループ (RHEL 系のグループ名。Debian には存在しない)
- `postgresql-server` 等の RHEL 系パッケージ名
- 実在しない docker-compose `5.3.1`
- どの play からも参照されないロール

同じ腐り方を早期に検出するため CI に組み込む。

## 内容

`ansible/ansible-lint` の公式アクションを使い、`ansible/**` と本 workflow 自身の変更時のみ実行する。`working_directory: ansible` で `ansible.cfg` を読ませている。

## collection の導入でハマった点

アクションには `requirements_file` 入力があるが、**これは使っていない**。

`ansible-galaxy install -r requirements.yml` に `--force` を渡せないため、runner にプリインストール済みの `ansible.posix` を見つけて `Nothing to do. All requested collections are already installed.` で終わってしまう。ところがその場所は ansible-lint の探索対象外で、結果として落ちる。

```
syntax-check[unknown-module]: couldn't resolve module/action 'ansible.posix.authorized_key'.
roles/common/tasks/main.yml:14:3
```

`ANSIBLE_COLLECTIONS_PATH` を固定する方法も試したが、galaxy が「もう入っている」と判断する限り導入自体が走らないので解決しなかった。最終的に自前のステップで `--force` を付け、`~/.ansible/collections` へ確実に導入する形にした。

```yaml
- name: Install collection dependencies
  working-directory: ansible
  run: ansible-galaxy collection install -r requirements.yml --force
```

なお**ローカルでは最初から通っていた**。`~/.ansible/collections` に `ansible.posix` が既にあったためで、CI で初めて表面化した典型的な差分だった。

## 検証

CI で `Ansible Lint` / `Actionlint` ともにパス。ローカルでも `production` プロファイルで 0 failure。

```console
$ uvx --with ansible-core ansible-lint
Passed: 0 failure(s), 0 warning(s) in 8 files processed of 12 encountered.
Last profile that met the validation criteria was 'production'.
```

## ついでに

ルート README のロール一覧が削除済みの `docker-compose` / `postgres` を載せたままだったので実態 (`common` のみ) に修正し、バッジと CI の説明を追加した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)