### PR TITLE
feat(hcp): HCP Terraform のワークスペース設定を IaC 管理下に置く

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -27,6 +27,7 @@ jobs:
           - terraform/aws/common-r53
           - terraform/aws/root
           - terraform/azure
+          - terraform/hcpterraform
           - terraform/homelab
           - terraform/newrelic
           - terraform/pagerduty

--- a/terraform/hcpterraform/.terraform.lock.hcl
+++ b/terraform/hcpterraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/tfe" {
+  version     = "0.79.0"
+  constraints = "~> 0.79.0"
+  hashes = [
+    "h1:+FAkz75Fes67OY0I10RpSZAQ2cvJHIarVXH+mLkar48=",
+    "h1:teVdOezI465bLv/C8vhyvEoC/0QSFwsOo00skZNn/NU=",
+    "h1:x67X4F77UZWISu1liYcHwMvEaJ4mjFh+J1UUOXF4CPU=",
+    "zh:212a4b646f5340362f8f860c4446f6430a0203956f5943eb6ebe35d0d8d6ea7c",
+    "zh:3209e7a5ed101f7293de75488ee7ce01c49b588cfe7fa4c59712d9ac9ec0e1e7",
+    "zh:48cf8b5646aba57718d4dd138a1a8101b3c357c13f8b534ede6b100feb1d00b0",
+    "zh:541d4532c875b2ee7ecb98da9a1461e76788893b623b0adf7c634d9fff7770e3",
+    "zh:60f5280d2162fe3e6c99896a84f61d986040e4432913e573b2fe7f138a5d1fa5",
+    "zh:73eb51fc3f28f05b8f5dd8baf4358d20852eda135cd465f35e7dfff4f2678c15",
+    "zh:7e64353b65f9467601904dfe64370d792fb03d5826c5e3c62a997c0babfd4fec",
+    "zh:8b696ab52dc76dc61489e27390fedcebae96fc7c6ade5dcb2d74ed2d76455e80",
+    "zh:91314784ff1c850dbb19722204266610154cc2ee8b5214b8b3f06f17023dce59",
+    "zh:94cf37180f01866c791b4769685d4f78d4b42744b8e220f9ce0a3333fff4b22a",
+    "zh:bdd6e6ec677c4b8c504c6e0bde112136c3c22e473f0213044ede34f29a57e910",
+    "zh:e82e6707e2aa70f7c23d7706e54749835b735195f3b79904548fa2189adaffb7",
+    "zh:fdc9036bd917fa2694f39c5738c5e41b89dcca4465d04f6c98e8deed03919a42",
+  ]
+}

--- a/terraform/hcpterraform/README.md
+++ b/terraform/hcpterraform/README.md
@@ -61,15 +61,22 @@ HCP は state の保管場所としてのみ使われ、plan / apply は手元�
 
 | 変数 | 種別 | Sensitive | 説明 |
 |------|------|-----------|------|
-| `TFE_TOKEN` | **Terraform** | Yes | org owner 権限の API トークン |
+| `TFE_TOKEN` | **Environment** | Yes | org owner 権限の API トークン |
 
-種別が Environment ではなく **Terraform** である点に注意。`tfe` provider は
-環境変数 `TFE_TOKEN` を読む仕様だが、それに頼ると「変数は設定したのに認証が
-通らない」という分かりにくい失敗をする。[providers.tf](providers.tf) で
-`token = var.TFE_TOKEN` と明示的に渡す形にしてある。
+**種別は Environment**。`tfe` provider が環境変数から直接読む標準の方式で、
+[providers.tf](providers.tf) に `token` を書く必要も、`variable "TFE_TOKEN"` を
+宣言する必要も無い。
 
-空にしておくと provider 標準の探索 (環境変数 → Terraform CLI config の
-credentials) にフォールバックする。手元から実行する場合はこの経路になる。
+Terraform 種別にすると次の不利益がある。
+
+- 機密値が plan の成果物に含まれ、HCP に保存される。環境変数は含まれない
+  (`sensitive` は表示を隠すだけで、格納先の話は別)
+- provider が読まないので `token = var.TFE_TOKEN` という glue が必要になる
+- `tflint-ignore: terraform_unused_declarations` 付きのダミー宣言が増える
+
+手元から実行する場合は Terraform CLI config の credentials
+(`~/.terraformrc-morihaya`) が使われる。詳細はリポジトリルートの
+[README](../../README.md#-local-hcp-terraform-credentials) を参照。
 
 > [!NOTE]
 > **新規ワークスペースは初回だけ手動で run をキューする必要がある。**

--- a/terraform/hcpterraform/README.md
+++ b/terraform/hcpterraform/README.md
@@ -1,0 +1,109 @@
+# HCP Terraform - ワークスペース管理
+
+HCP Terraform 自体を Terraform で管理するルート。本リポジトリが使う
+ワークスペースの設定をコード化する。
+
+## なぜやるのか
+
+ワークスペースの設定は UI にしか無く、**壊れていても気づけない**。
+実際に 2026-07 の調査で以下が判明した。
+
+- `morihaya-infra-newrelic` / `-pagerduty` / `-tailscale` が **Terraform 1.0.8** のまま
+- `auto_apply` がワークスペースごとにバラバラ (`-aws-common-r53` と `-azure` だけ有効)
+- `speculative_enabled` も不統一。無効なワークスペースは PR 時に plan が走らない
+- `working_directory` の先頭・末尾スラッシュ、`trigger_patterns` の `./` 有無が不統一
+- ワークスペースの `terraform_version` が `~>1.14.0` なのにリポジトリの
+  [.terraform-version](../../.terraform-version) は `1.15.0` で不整合。
+  ローカルから state を操作しようとすると弾かれる
+
+さらに、Dependabot の run が確認待ちのまま 1 ヶ月以上放置されて
+ワークスペースがロックし、その裏で apply が半年止まっていたことも
+[#64](https://github.com/morihaya/morihaya-infra/pull/64) で判明した。
+UI 任せの運用が実害を出している。
+
+## 管理対象
+
+| ワークスペース | project | working_directory | exec | Terraform | auto_apply | speculative |
+|---|---|---|---|---|---|---|
+| `-aws-common-r53` | AWS | `terraform/aws/common-r53` | remote | `~>1.14.0` | **true** | true |
+| `-aws-root` | AWS | `terraform/aws/root/` | remote | `~>1.14.0` | false | **false** |
+| `-azure` | Azure | `/terraform/azure` | remote | `~>1.14.0` | **true** | true |
+| `-homelab` | HomeLab | `/terraform/homelab` | **agent** | `~>1.14.0` | false | true |
+| `-newrelic` | Default | `/terraform/newrelic/` | remote | **1.0.8** | false | **false** |
+| `-pagerduty` | Default | (なし) | **local** | **1.0.8** | false | false |
+| `-tailscale` | Default | (なし) | **local** | **1.0.8** | false | false |
+
+`-pagerduty` と `-tailscale` は VCS 連携が無く `execution_mode = local`。
+HCP は state の保管場所としてのみ使われ、plan / apply は手元で走る。
+
+`terraform/spotify` は HCP を使わずローカル state なので、対応する
+ワークスペースは存在しない。
+
+> [!IMPORTANT]
+> 現時点のコードは**実態をそのまま写し取っているだけ**で、上表のバラつきは
+> 意図的に現状のまま記述している。plan を no-op に保つため。
+> 統一は別 PR で行う。
+
+## 自分自身は管理しない
+
+このルートを動かす `morihaya-infra` ワークスペース (working directory
+`/terraform/hcpterraform`) は**管理対象に含めていない**。自分が乗っている枝を
+切る事故を防ぐため、このワークスペースだけは手動で作成・管理する。
+
+ワークスペースの `destroy` は **state の消失**を意味するため、全ワークスペースに
+`prevent_destroy = true` を付けている。
+
+## 認証情報
+
+`tfe` provider には org の owners team 権限を持つ API トークンが必要で、
+これは**本リポジトリで使うどの認証情報よりも強い**。ワークスペース
+`morihaya-infra` の環境変数 `TFE_TOKEN` に sensitive で設定する。
+
+| 変数 | 種別 | Sensitive | 説明 |
+|------|------|-----------|------|
+| `TFE_TOKEN` | Environment | Yes | org owner 権限の API トークン |
+
+## 変数の値は管理しない
+
+各ワークスペースが必要とする変数は org の variable set 側にあり、本ルートでは
+**管理していない**。理由は 2 つ。
+
+1. 機密値をコードに置けない。このリポジトリは公開されている
+2. アカウント ID (`aws_accountid` / `newrelic_accountid`) やエンドポイントは
+   機密ではないが識別情報になる。公開する実益が無い
+
+将来的には Proxmox 上に HashiCorp Vault (Community Edition) を立て、そちらで
+認証情報を管理する方針。その時点で variable set の扱いを再検討する。
+
+## 不透明な識別子をコードに書かない
+
+project ID / agent pool ID / GitHub App installation ID は `ghain-xxxx` のような
+HCP 内部の識別子だが、公開リポジトリに並べる必要が無いので**全てデータソースで
+名前から引いている**。
+
+```hcl
+data "tfe_project" "homelab" {
+  name         = "HomeLab"
+  organization = var.tfe_organization
+}
+```
+
+## Usage
+
+```bash
+terraform init
+```
+
+```bash
+terraform plan
+```
+
+初回 apply 後は [imports.tf](imports.tf) を削除してよい。
+
+## 今後
+
+- [ ] `terraform_version` を全ワークスペースで統一し、`.terraform-version` と揃える
+- [ ] `working_directory` と `trigger_patterns` の表記を統一する
+- [ ] `speculative_enabled` を全ワークスペースで有効にし、PR 時に必ず plan させる
+- [ ] `auto_apply` の方針を決める (現在は 2 つだけ有効で一貫していない)
+- [ ] Vault 導入後に variable set の管理方法を再検討する

--- a/terraform/hcpterraform/README.md
+++ b/terraform/hcpterraform/README.md
@@ -61,7 +61,23 @@ HCP は state の保管場所としてのみ使われ、plan / apply は手元�
 
 | 変数 | 種別 | Sensitive | 説明 |
 |------|------|-----------|------|
-| `TFE_TOKEN` | Environment | Yes | org owner 権限の API トークン |
+| `TFE_TOKEN` | **Terraform** | Yes | org owner 権限の API トークン |
+
+種別が Environment ではなく **Terraform** である点に注意。`tfe` provider は
+環境変数 `TFE_TOKEN` を読む仕様だが、それに頼ると「変数は設定したのに認証が
+通らない」という分かりにくい失敗をする。[providers.tf](providers.tf) で
+`token = var.TFE_TOKEN` と明示的に渡す形にしてある。
+
+空にしておくと provider 標準の探索 (環境変数 → Terraform CLI config の
+credentials) にフォールバックする。手元から実行する場合はこの経路になる。
+
+> [!NOTE]
+> **新規ワークスペースは初回だけ手動で run をキューする必要がある。**
+> `queue_all_runs = false` の場合、HCP は「一度も手動で run がキューされて
+> いないワークスペース」では webhook 起因の run をキューしない。
+> 実際にこのワークスペースは作成から半年間 run が 0 件で、VCS 連携の設定は
+> 正しいのに PR を出しても plan が走らなかった。UI から一度 "Start new run"
+> すれば以降は自動で走る。
 
 ## 変数の値は管理しない
 

--- a/terraform/hcpterraform/imports.tf
+++ b/terraform/hcpterraform/imports.tf
@@ -1,0 +1,40 @@
+# =============================================================================
+# 既存ワークスペースの取り込み
+#
+# tfe_workspace の import ID は "<organization>/<workspace name>"。
+# apply が完了したらこのファイルは削除してよい。
+# =============================================================================
+import {
+  to = tfe_workspace.this["aws-common-r53"]
+  id = "morihaya/morihaya-infra-aws-common-r53"
+}
+
+import {
+  to = tfe_workspace.this["aws-root"]
+  id = "morihaya/morihaya-infra-aws-root"
+}
+
+import {
+  to = tfe_workspace.this["azure"]
+  id = "morihaya/morihaya-infra-azure"
+}
+
+import {
+  to = tfe_workspace.this["homelab"]
+  id = "morihaya/morihaya-infra-homelab"
+}
+
+import {
+  to = tfe_workspace.this["newrelic"]
+  id = "morihaya/morihaya-infra-newrelic"
+}
+
+import {
+  to = tfe_workspace.this["pagerduty"]
+  id = "morihaya/morihaya-infra-pagerduty"
+}
+
+import {
+  to = tfe_workspace.this["tailscale"]
+  id = "morihaya/morihaya-infra-tailscale"
+}

--- a/terraform/hcpterraform/providers.tf
+++ b/terraform/hcpterraform/providers.tf
@@ -1,11 +1,12 @@
-# 認証トークンはワークスペース変数 TFE_TOKEN から受け取る。
-# このトークンは org の owners team のものが必要で、本リポジトリで使う
+# 認証は環境変数 TFE_TOKEN で行う (provider 標準の方式)。
+# HCP Terraform 側ではワークスペース morihaya-infra の
+# Environment variable として sensitive で設定する。
+#
+# このトークンは org の owners team 権限が必要で、本リポジトリで使う
 # どの認証情報よりも強い。詳細は README.md を参照。
 #
-# 空の場合は null を渡し、provider 標準の探索
-# (環境変数 TFE_TOKEN → Terraform CLI config の credentials) に委ねる。
-# 手元から実行する場合は ~/.terraformrc-morihaya がこれで使われる。
+# 手元から実行する場合は Terraform CLI config の credentials
+# (~/.terraformrc-morihaya) が使われる。
 provider "tfe" {
   organization = var.tfe_organization
-  token        = var.TFE_TOKEN != "" ? var.TFE_TOKEN : null
 }

--- a/terraform/hcpterraform/providers.tf
+++ b/terraform/hcpterraform/providers.tf
@@ -1,6 +1,11 @@
-# 認証は HCP Terraform ワークスペースの環境変数 TFE_TOKEN で行う。
+# 認証トークンはワークスペース変数 TFE_TOKEN から受け取る。
 # このトークンは org の owners team のものが必要で、本リポジトリで使う
 # どの認証情報よりも強い。詳細は README.md を参照。
+#
+# 空の場合は null を渡し、provider 標準の探索
+# (環境変数 TFE_TOKEN → Terraform CLI config の credentials) に委ねる。
+# 手元から実行する場合は ~/.terraformrc-morihaya がこれで使われる。
 provider "tfe" {
   organization = var.tfe_organization
+  token        = var.TFE_TOKEN != "" ? var.TFE_TOKEN : null
 }

--- a/terraform/hcpterraform/providers.tf
+++ b/terraform/hcpterraform/providers.tf
@@ -1,0 +1,6 @@
+# 認証は HCP Terraform ワークスペースの環境変数 TFE_TOKEN で行う。
+# このトークンは org の owners team のものが必要で、本リポジトリで使う
+# どの認証情報よりも強い。詳細は README.md を参照。
+provider "tfe" {
+  organization = var.tfe_organization
+}

--- a/terraform/hcpterraform/variables.tf
+++ b/terraform/hcpterraform/variables.tf
@@ -1,9 +1,8 @@
 # =============================================================================
 # Variables provided by the HCP Terraform workspace
 # =============================================================================
-# tflint-ignore: terraform_unused_declarations
 variable "TFE_TOKEN" {
-  description = "HCP Terraform API token with org owner permissions (also consumed by the provider via environment variable)"
+  description = "HCP Terraform API token with org owner permissions. Set as a sensitive Terraform variable on the morihaya-infra workspace. Leave empty to fall back to the provider's own discovery (TFE_TOKEN environment variable, then the Terraform CLI config credentials) — that is what local runs use."
   type        = string
   sensitive   = true
   default     = ""

--- a/terraform/hcpterraform/variables.tf
+++ b/terraform/hcpterraform/variables.tf
@@ -1,12 +1,8 @@
 # =============================================================================
-# Variables provided by the HCP Terraform workspace
+# 認証トークン (TFE_TOKEN) はここで宣言しない。
+# provider が環境変数から直接読むため、Terraform 変数として宣言する必要が無い。
+# 宣言してしまうと tflint-ignore 付きのダミー宣言が増えるだけになる。
 # =============================================================================
-variable "TFE_TOKEN" {
-  description = "HCP Terraform API token with org owner permissions. Set as a sensitive Terraform variable on the morihaya-infra workspace. Leave empty to fall back to the provider's own discovery (TFE_TOKEN environment variable, then the Terraform CLI config credentials) — that is what local runs use."
-  type        = string
-  sensitive   = true
-  default     = ""
-}
 
 variable "tfe_organization" {
   description = "HCP Terraform organization that owns the workspaces"

--- a/terraform/hcpterraform/variables.tf
+++ b/terraform/hcpterraform/variables.tf
@@ -1,0 +1,34 @@
+# =============================================================================
+# Variables provided by the HCP Terraform workspace
+# =============================================================================
+# tflint-ignore: terraform_unused_declarations
+variable "TFE_TOKEN" {
+  description = "HCP Terraform API token with org owner permissions (also consumed by the provider via environment variable)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "tfe_organization" {
+  description = "HCP Terraform organization that owns the workspaces"
+  type        = string
+  default     = "morihaya"
+}
+
+variable "vcs_repo_identifier" {
+  description = "GitHub repository backing the VCS-driven workspaces"
+  type        = string
+  default     = "morihaya/morihaya-infra"
+}
+
+variable "github_app_installation_name" {
+  description = "Name of the GitHub App installation used for VCS connections. Resolved to an id by a data source so no opaque identifier lives in this public repository."
+  type        = string
+  default     = "morihaya"
+}
+
+variable "homelab_agent_pool_name" {
+  description = "Agent pool that runs the homelab workspace (the agent VM lives on the Proxmox cluster)"
+  type        = string
+  default     = "homelab01"
+}

--- a/terraform/hcpterraform/versions.tf
+++ b/terraform/hcpterraform/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  cloud {
+    organization = "morihaya"
+
+    workspaces {
+      name = "morihaya-infra"
+    }
+  }
+
+  required_providers {
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.79.0"
+    }
+  }
+}

--- a/terraform/hcpterraform/workspaces.tf
+++ b/terraform/hcpterraform/workspaces.tf
@@ -1,0 +1,205 @@
+# =============================================================================
+# HCP Terraform workspaces used by this repository
+#
+# ここは「HCP Terraform 自体を管理する」ルート。UI でしか見えない設定が
+# 長期間放置されて実害が出たため IaC 化した (詳細は README.md)。
+#
+# 【重要】この時点では実態をそのまま写し取ることだけを目的としている。
+# 下表のとおり terraform_version / auto_apply / speculative / working_directory
+# はワークスペースごとにバラバラだが、意図的に現状のまま記述して plan を
+# no-op に保っている。統一は別 PR で行う。
+#
+# 【自分自身は管理しない】このルートを動かす morihaya-infra ワークスペースは
+# 管理対象に含めない。自分が乗っている枝を切る事故を防ぐため。
+# =============================================================================
+
+data "tfe_github_app_installation" "this" {
+  name = var.github_app_installation_name
+}
+
+data "tfe_agent_pool" "homelab" {
+  name         = var.homelab_agent_pool_name
+  organization = var.tfe_organization
+}
+
+data "tfe_project" "aws" {
+  name         = "AWS"
+  organization = var.tfe_organization
+}
+
+data "tfe_project" "azure" {
+  name         = "Azure"
+  organization = var.tfe_organization
+}
+
+data "tfe_project" "homelab" {
+  name         = "HomeLab"
+  organization = var.tfe_organization
+}
+
+data "tfe_project" "default" {
+  name         = "Default Project"
+  organization = var.tfe_organization
+}
+
+locals {
+  # 現状のワークスペース設定。値は 2026-07-26 時点の実態。
+  workspaces = {
+    aws-common-r53 = {
+      name              = "morihaya-infra-aws-common-r53"
+      description       = "共通系のr53を管理する。テスト用としても。"
+      project_id        = data.tfe_project.aws.id
+      working_directory = "terraform/aws/common-r53"
+      trigger_patterns  = ["/terraform/aws/common-r53/*.tf"]
+      terraform_version = "~>1.14.0"
+      execution_mode    = "remote"
+      # このワークスペースだけ auto_apply が有効。マージした時点で適用される。
+      auto_apply             = true
+      auto_apply_run_trigger = true
+      speculative_enabled    = true
+      vcs                    = true
+    }
+
+    aws-root = {
+      name        = "morihaya-infra-aws-root"
+      description = "My personal AWS root"
+      project_id  = data.tfe_project.aws.id
+      # 末尾スラッシュ付き。他と不統一だが実態どおり。
+      working_directory = "terraform/aws/root/"
+      # 先頭 "./" 付き。他と不統一だが実態どおり。
+      trigger_patterns       = ["./terraform/aws/root/*.tf"]
+      terraform_version      = "~>1.14.0"
+      execution_mode         = "remote"
+      auto_apply             = false
+      auto_apply_run_trigger = false
+      # speculative 無効。PR 時に plan が走らない。
+      speculative_enabled = false
+      vcs                 = true
+    }
+
+    azure = {
+      name                   = "morihaya-infra-azure"
+      description            = null
+      project_id             = data.tfe_project.azure.id
+      working_directory      = "/terraform/azure"
+      trigger_patterns       = ["/terraform/azure/*.tf"]
+      terraform_version      = "~>1.14.0"
+      execution_mode         = "remote"
+      auto_apply             = true
+      auto_apply_run_trigger = true
+      speculative_enabled    = true
+      vcs                    = true
+    }
+
+    homelab = {
+      name              = "morihaya-infra-homelab"
+      description       = null
+      project_id        = data.tfe_project.homelab.id
+      working_directory = "/terraform/homelab"
+      trigger_patterns  = ["/terraform/homelab/*.tf"]
+      terraform_version = "~>1.14.0"
+      # Proxmox の API はインターネットから到達できないため agent 実行。
+      # agent は VM 103 (pve 上) で動いている。
+      execution_mode         = "agent"
+      auto_apply             = false
+      auto_apply_run_trigger = false
+      speculative_enabled    = true
+      vcs                    = true
+    }
+
+    newrelic = {
+      name              = "morihaya-infra-newrelic"
+      description       = null
+      project_id        = data.tfe_project.default.id
+      working_directory = "/terraform/newrelic/"
+      trigger_patterns  = ["/terraform/newrelic/*.tf"]
+      # Terraform 1.0.8 のまま。要更新。
+      terraform_version      = "1.0.8"
+      execution_mode         = "remote"
+      auto_apply             = false
+      auto_apply_run_trigger = false
+      speculative_enabled    = false
+      vcs                    = true
+    }
+
+    # pagerduty と tailscale は VCS 連携が無く execution_mode = local。
+    # HCP は state の保管場所としてのみ使われ、plan/apply は手元で走る。
+    pagerduty = {
+      name                   = "morihaya-infra-pagerduty"
+      description            = null
+      project_id             = data.tfe_project.default.id
+      working_directory      = ""
+      trigger_patterns       = []
+      terraform_version      = "1.0.8"
+      execution_mode         = "local"
+      auto_apply             = false
+      auto_apply_run_trigger = false
+      speculative_enabled    = false
+      vcs                    = false
+    }
+
+    tailscale = {
+      name                   = "morihaya-infra-tailscale"
+      description            = "https://tailscale.com/"
+      project_id             = data.tfe_project.default.id
+      working_directory      = ""
+      trigger_patterns       = []
+      terraform_version      = "1.0.8"
+      execution_mode         = "local"
+      auto_apply             = false
+      auto_apply_run_trigger = false
+      speculative_enabled    = false
+      vcs                    = false
+    }
+  }
+}
+
+resource "tfe_workspace" "this" {
+  for_each = local.workspaces
+
+  name         = each.value.name
+  organization = var.tfe_organization
+  project_id   = each.value.project_id
+  description  = each.value.description
+
+  working_directory = each.value.working_directory
+  terraform_version = each.value.terraform_version
+
+  execution_mode = each.value.execution_mode
+  agent_pool_id  = each.value.execution_mode == "agent" ? data.tfe_agent_pool.homelab.id : null
+
+  auto_apply             = each.value.auto_apply
+  auto_apply_run_trigger = each.value.auto_apply_run_trigger
+  speculative_enabled    = each.value.speculative_enabled
+
+  file_triggers_enabled = each.value.vcs
+  trigger_patterns      = each.value.trigger_patterns
+
+  queue_all_runs      = false
+  allow_destroy_plan  = true
+  assessments_enabled = false
+
+  dynamic "vcs_repo" {
+    for_each = each.value.vcs ? [1] : []
+    content {
+      identifier                 = var.vcs_repo_identifier
+      github_app_installation_id = data.tfe_github_app_installation.this.id
+      ingress_submodules         = false
+    }
+  }
+
+  lifecycle {
+    # ワークスペースの destroy は state の消失を意味する。
+    # 意図せぬ削除を確実に止める。
+    prevent_destroy = true
+  }
+}
+
+## Output Values
+output "workspace_settings" {
+  description = "Current settings of the managed workspaces, for spotting drift at a glance"
+  value = {
+    for k, w in tfe_workspace.this :
+    w.name => "tf=${w.terraform_version} exec=${w.execution_mode} auto_apply=${w.auto_apply} speculative=${w.speculative_enabled} wd=${w.working_directory}"
+  }
+}


### PR DESCRIPTION
> [!WARNING]
> **マージ前に `morihaya-infra` ワークスペースへ環境変数 `TFE_TOKEN` (sensitive) の設定が必要です。**
> 未設定だと本 PR の HCP チェックが認証エラーで失敗します。org の owners team 権限を持つ API トークンを設定してください。

## 背景

ワークスペースの設定は UI にしか無く、**壊れていても気づけない**。実際に調査で以下が判明した。

- `-newrelic` / `-pagerduty` / `-tailscale` が **Terraform 1.0.8** のまま
- `auto_apply` がバラバラ (`-aws-common-r53` と `-azure` だけ有効)
- `speculative_enabled` も不統一。無効なワークスペースは PR 時に plan が走らない
- `working_directory` の先頭・末尾スラッシュ、`trigger_patterns` の `./` 有無が不統一
- ワークスペースの `terraform_version` が `~>1.14.0` なのに `.terraform-version` は `1.15.0` で不整合

加えて Dependabot の run が確認待ちのまま 1 ヶ月以上放置されてワークスペースがロックし、**apply が半年止まっていた** ([#64](https://github.com/morihaya/morihaya-infra/pull/64))。UI 任せの運用が実害を出している。

## スコープ

本リポジトリが使う **7 ワークスペースのみ**。

| ワークスペース | project | working_directory | exec | Terraform | auto_apply | speculative |
|---|---|---|---|---|---|---|
| `-aws-common-r53` | AWS | `terraform/aws/common-r53` | remote | `~>1.14.0` | **true** | true |
| `-aws-root` | AWS | `terraform/aws/root/` | remote | `~>1.14.0` | false | **false** |
| `-azure` | Azure | `/terraform/azure` | remote | `~>1.14.0` | **true** | true |
| `-homelab` | HomeLab | `/terraform/homelab` | **agent** | `~>1.14.0` | false | true |
| `-newrelic` | Default | `/terraform/newrelic/` | remote | **1.0.8** | false | **false** |
| `-pagerduty` | Default | (なし) | **local** | **1.0.8** | false | false |
| `-tailscale` | Default | (なし) | **local** | **1.0.8** | false | false |

org の project と variable set は**管理しない**。将来 Proxmox 上に HashiCorp Vault (Community Edition) を立てて認証情報を管理する方針なので、その時点で variable set の扱いを再検討する。

**変数の値も管理しない。** 機密値は公開リポジトリに置けず、アカウント ID (`aws_accountid` / `newrelic_accountid`) 等は機密ではないが識別情報になるため公開する実益が無い。

## 設計

| 判断 | 理由 |
|---|---|
| **自分自身を管理対象に含めない** | このルートを動かす `morihaya-infra` ワークスペースは手動管理。自分が乗っている枝を切る事故を防ぐ |
| **全ワークスペースに `prevent_destroy`** | ワークスペースの destroy は **state の消失**を意味する |
| **ID は data source で名前引き** | project / agent pool / GitHub App installation の `ghain-xxxx` 等を公開リポジトリに並べない |
| **既存のバラつきは現状のまま記述** | plan を no-op に保つため。統一は別 PR |

VCS 連携は OAuth ではなく **GitHub App** (`service-provider: github_app`) なので `github_app_installation_id` を使っている。

## 検証

ローカル state で import plan を実行し、**完全な no-op** を確認済み。

```
Plan: 7 to import, 0 to add, 0 to change, 0 to destroy.
```

`terraform fmt` / `tflint` / `validate` / `actionlint` すべてパス。`terraform-validate.yml` のマトリクスはハードコードなので新ルートを追加した。

## マージ後

1. HCP で Confirm & Apply (`morihaya-infra` は `auto_apply = false`)
2. [imports.tf](terraform/hcpterraform/imports.tf) を削除

## 今後 (README に TODO として記載)

- `terraform_version` を統一し `.terraform-version` と揃える
- `working_directory` と `trigger_patterns` の表記統一
- `speculative_enabled` を全ワークスペースで有効化し、PR 時に必ず plan させる
- `auto_apply` の方針決定
- Vault 導入後に variable set の管理方法を再検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)