### PR TITLE
fix(homelab): VM 103 の CD-ROM 取り外しをコードへ反映する

### DIFF
--- a/terraform/homelab/103vm_hcp_terraform_agent.tf
+++ b/terraform/homelab/103vm_hcp_terraform_agent.tf
@@ -31,11 +31,10 @@ resource "proxmox_virtual_environment_vm" "vm_103" {
     iothread     = true
   }
 
-  # CD-ROM (ide2) - Ubuntu ISOがマウントされている
-  cdrom {
-    file_id   = "local:iso/ubuntu-24.04.3-live-server-amd64.iso"
-    interface = "ide2"
-  }
+  # CD-ROM (ide2) はインストール完了後も刺さったままだったが、その ISO は
+  # pve の local ストレージにしか存在せず、このVMのマイグレーションを
+  # 妨げていた。ZFS 移行の事前準備 (docs/zfs-ha-migration.md の Phase 0-3) で
+  # `qm set 103 --delete ide2` により取り外したため、定義ごと削除する。
 
   # ネットワーク設定
   network_device {
@@ -55,8 +54,8 @@ resource "proxmox_virtual_environment_vm" "vm_103" {
     type = "l26"
   }
 
-  # Boot順序
-  boot_order = ["scsi0", "ide2", "net0"]
+  # Boot順序 (ide2 取り外しに伴い scsi0 のみ)
+  boot_order = ["scsi0"]
 
   # QEMU Guest Agent (現在無効)
   #agent {

--- a/terraform/homelab/docs/zfs-ha-migration.md
+++ b/terraform/homelab/docs/zfs-ha-migration.md
@@ -80,7 +80,13 @@ ssh root@192.168.1.2 'for id in 100 101 102 104; do vzdump $id --storage local -
 ssh root@192.168.1.2 'vzdump 103 --storage local --mode stop --compress zstd'
 ```
 
-`ct:105` は pve3 上にあるので pve3 側で取得する。
+`ct:105` は pve3 上にあるので pve3 側で取得する。**取り漏らしやすいので注意**
+(2026-07-26 の実施時、pve 側の 5 台は取得されたが pve3 の `ct:105` は
+未取得だった)。
+
+```bash
+ssh root@192.168.1.11 'vzdump 105 --storage local --mode snapshot --compress zstd'
+```
 
 ### 0-2. ノード間 SSH の疎通確認
 
@@ -100,6 +106,33 @@ ssh root@192.168.1.2 'for h in 192.168.1.10 192.168.1.11; do ssh-keyscan -H $h >
 ```bash
 ssh root@192.168.1.2 'qm set 103 --delete ide2 && qm set 103 --boot order=scsi0'
 ```
+
+> [!WARNING]
+> **VM が起動中だとこの変更は `[PENDING]` に入り、即時反映されない。**
+> `/etc/pve/qemu-server/103.conf` の末尾に次のセクションが付く。
+>
+> ```
+> [PENDING]
+> boot: order=scsi0
+> delete: ide2
+> ```
+>
+> 反映には VM の停止・起動が必要 (ゲスト OS 内からの再起動では不十分)。
+> **保留のままだと稼働中の VM には ISO が刺さったままなので、
+> マイグレーションできず Phase 0-3 の目的を達成できない。**
+>
+> ```bash
+> ssh root@192.168.1.2 'qm stop 103 && qm start 103'
+> ```
+>
+> 停止中は HCP Terraform の Agent も止まるため、plan / apply が実行できない
+> ことに注意。
+
+> [!IMPORTANT]
+> Proxmox の API は保留後の値を返すため、この操作の直後から Terraform に
+> 差分が出る。[103vm_hcp_terraform_agent.tf](../103vm_hcp_terraform_agent.tf)
+> は対応済み (`cdrom` ブロックを削除し `boot_order = ["scsi0"]`)。
+> 未対応のまま apply すると `ide2` と `net0` を boot 順序へ戻そうとする。
 
 > [!IMPORTANT]
 > 103 は HCP Terraform の Agent であり、これが停止している間は Terraform の


### PR DESCRIPTION
## 問題

ZFS 移行の事前準備 ([Phase 0-3](terraform/homelab/docs/zfs-ha-migration.md)) で実施した

```bash
qm set 103 --delete ide2 && qm set 103 --boot order=scsi0
```

によりコードと実態が乖離し、apply 時に差分が出ていた。

```hcl
~ boot_order = [
      "scsi0",
    + "ide2",
    + "net0",
  ]
```

## 原因

VM 103 が**起動中**のため、この変更は即時反映されず `[PENDING]` に入っていた。

```console
$ cat /etc/pve/qemu-server/103.conf
...
boot: order=scsi0;ide2;net0
ide2: local:iso/ubuntu-24.04.3-live-server-amd64.iso,media=cdrom,size=3226020K
...
[PENDING]
boot: order=scsi0
delete: ide2
```

**Proxmox の API は保留後の値を返す。**

```console
$ pvesh get /nodes/pve/qemu/103/config
boot: order=scsi0
ide2: None
```

つまり Terraform からは反映後の状態に見えるため、コードが古いままだと「取り外したはずの `ide2` と `net0` を boot 順序へ戻す」差分になる。

## 修正

- `cdrom` ブロックを削除。ISO は pve の `local` にしか存在せず、このVMのマイグレーションを妨げていた経緯をコメントとして残した
- `boot_order` を `["scsi0"]` に変更

`terraform plan` が `No changes. Your infrastructure matches the configuration.` になることを確認済み。

## 手順書の補強

同じ手順を踏む人が同じところで詰まるので、3点を追記した。

1. **起動中の VM では変更が `[PENDING]` に入り、停止・起動しないと反映されない**（ゲスト OS 内からの再起動では不十分）。保留のままでは稼働中の VM に ISO が刺さったままなので**マイグレーションできず Phase 0-3 の目的を達成できない**
2. この操作の直後から Terraform に差分が出るため、コード側の対応が必要
3. `ct:105` のバックアップは pve3 側で取る必要があり取り漏らしやすい

🤖 Generated with [Claude Code](https://claude.com/claude-code)