### PR TITLE
feat(homelab): ZFS 移行完了に伴い HA を有効化する

### DIFF
--- a/terraform/homelab/README.md
+++ b/terraform/homelab/README.md
@@ -30,21 +30,24 @@
 
 ## High Availability
 
-> [!IMPORTANT]
-> **現状 HA は未稼働。** 2026-07-25 に pve が停止した際、DNS / DHCP / Traefik が
-> 揃って落ちた。3 ノードのクラスタは正常だったが、HA 登録されていたのが
-> `ct:105` の 1 件のみで、かつ共有ストレージもレプリケーションも無かったため。
+2026-07-25 に pve が停止した際、DNS / DHCP / Traefik が揃って落ちた。3 ノードの
+クラスタは正常だったが、HA 登録されていたのが `ct:105` の 1 件のみで、かつ
+共有ストレージもレプリケーションも無かったため。
 
-有効化には ZFS への移行 (破壊的作業) が必要で、手順は
-[docs/zfs-ha-migration.md](docs/zfs-ha-migration.md) にまとめてある。
-移行が全ノードで完了してから、ワークスペース変数を以下に変更して apply する。
+その恒久対策として **2026-07-26 に全ノードを ZFS 化**し、`pvesr` による
+ストレージレプリケーションと HA を有効化した。移行の記録は
+[docs/zfs-ha-migration.md](docs/zfs-ha-migration.md) を参照。
 
-| 変数 | 移行前 | 移行後 |
-|------|--------|--------|
-| `guest_datastore_id` | `local-lvm` | `local-zfs` |
-| `enable_ha` | `false` | `true` |
+| 変数 | 移行前 | 現在 |
+|------|--------|------|
+| `guest_datastore_id` | `local-lvm` | **`local-zfs`** |
+| `enable_ha` | `false` | **`true`** |
 
-`enable_ha = false` の間、[ha.tf](ha.tf) のリソースは一切作られない。
+> [!NOTE]
+> この 2 つは**コード内の `default` で管理しており、HCP のワークスペース変数
+> としては設定していない**。UI に隠れた状態を作らず、PR の speculative plan で
+> 差分を確認できるようにするため。変更する場合は
+> [variables.tf](variables.tf) を編集する。
 
 HA 有効時のフェイルオーバー設計は [ha.tf](ha.tf) の `local.ha_guests` を参照。
 共有ストレージが無いため、レプリカを持つ 2 ノードにだけ移動を許す
@@ -116,8 +119,6 @@ pveum user token add terraform@pve provider --privsep=0
 | `PROXMOX_VE_ENDPOINT` | Environment | No | Proxmox API URL |
 | `PROXMOX_VE_API_TOKEN` | Environment | Yes | `terraform@pve!provider=xxx` |
 | `PROXMOX_VE_INSECURE` | Environment | No | 自己署名証明書なら `true` |
-| `guest_datastore_id` | Terraform | No | ゲストディスクの配置先 (既定 `local-lvm`) |
-| `enable_ha` | Terraform | No | HA とレプリケーションの有効化 (既定 `false`) |
 
 ### HCP Terraform Agent
 

--- a/terraform/homelab/docs/zfs-ha-migration.md
+++ b/terraform/homelab/docs/zfs-ha-migration.md
@@ -329,17 +329,28 @@ ssh root@192.168.1.10 'qm migrate 103 pve'
 
 ここまでで全ゲストのディスクが `local-zfs` 上にある状態になる。
 
-### 4-1. HCP Terraform ワークスペース変数を更新
+### 4-1. コードの default を更新
 
-ワークスペース `morihaya-infra-homelab` の Terraform 変数に以下を設定する。
+この 2 つは**コード内の `default` で管理する**。HCP のワークスペース変数として
+は設定しない (UI に隠れた状態を作らず、PR の speculative plan で差分を確認
+できるようにするため)。[variables.tf](../variables.tf) を編集する。
 
-| 変数 | 値 |
-|------|-----|
-| `guest_datastore_id` | `local-zfs` |
-| `enable_ha` | `true` |
+| 変数 | 変更前 | 変更後 |
+|------|--------|--------|
+| `guest_datastore_id` | `local-lvm` | `local-zfs` |
+| `enable_ha` | `false` | `true` |
 
-`guest_datastore_id` は実機の状態に追従させるための変数なので、
-**Phase 3 完了前に変更してはいけない** (ディスクの再作成が走る)。
+> [!WARNING]
+> `guest_datastore_id` は実機の状態に追従させるための変数なので、
+> **Phase 3 完了前に変更してはいけない**。逆に Phase 3 完了後に変更を忘れると、
+> コードが `local-lvm` を指したまま実機が `local-zfs` になり、plan が
+> **全コンテナの破壊・再作成**を出す。実際に 2026-07-26 の実施時、この状態で
+> 次の plan が出た。
+>
+> ```
+> ~ datastore_id = "local-zfs" -> "local-lvm" # forces replacement
+> Plan: 5 to add, 0 to change, 5 to destroy.
+> ```
 
 ### 4-2. 手動登録したストレージを Terraform へ引き継ぐ
 

--- a/terraform/homelab/imports.tf
+++ b/terraform/homelab/imports.tf
@@ -1,0 +1,13 @@
+# =============================================================================
+# ZFS 移行 (docs/zfs-ha-migration.md) の途中では、対象ノードが 1 台ずつ増えて
+# いくため `local-zfs` ストレージを pvesm で手動登録した。実体が既にあるので
+# 作成ではなく取り込む。
+#
+#   pvesm add zfspool local-zfs --pool rpool_data --content images,rootdir --nodes pve2
+#
+# apply 完了後、このファイルは削除してよい。
+# =============================================================================
+import {
+  to = proxmox_storage_zfspool.guest_storage[0]
+  id = var.zfs_storage_id
+}

--- a/terraform/homelab/variables.tf
+++ b/terraform/homelab/variables.tf
@@ -57,15 +57,15 @@ variable "proxmox_cluster_nodes" {
 # ゲストを起動しようとして失敗する。
 # =============================================================================
 variable "enable_ha" {
-  description = "Enable ZFS storage registration, storage replication and HA resources. Only set to true AFTER the local-lvm to ZFS migration described in docs/zfs-ha-migration.md is complete on every node."
+  description = "Enable ZFS storage registration, storage replication and HA resources. The local-lvm to ZFS migration completed on 2026-07-26, so this is now on by default."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "guest_datastore_id" {
-  description = "Datastore holding guest root disks. Switch to the ZFS storage id once the migration is complete; storage replication only works on ZFS."
+  description = "Datastore holding guest root disks. Storage replication only works on ZFS. Migrated from local-lvm on 2026-07-26; local-lvm no longer exists on any node."
   type        = string
-  default     = "local-lvm"
+  default     = "local-zfs"
 }
 
 variable "zfs_storage_id" {


### PR DESCRIPTION
2026-07-26 に全ノードの ZFS 化が完了したため、コードを実態に合わせて HA を有効化する。

## ⚠️ 先に直すべき危険な状態があった

移行完了後もコードが `local-lvm` を指したままだったため、**plan が全コンテナの破壊・再作成を出す状態**になっていた。

```
~ datastore_id = "local-zfs" -> "local-lvm" # forces replacement
Plan: 5 to add, 0 to change, 5 to destroy.
```

本 PR 適用後:

```
Plan: 1 to import, 15 to add, 1 to change, 0 to destroy.
```

## 設計の誤りを修正: ワークスペース変数 → コードの default

当初 `guest_datastore_id` と `enable_ha` は「移行後に HCP のワークスペース変数で設定する」設計にしていた。しかしこれは **UI に隠れた状態を作り、PR で差分を確認できない**。

実際、本件はワークスペース変数が未設定のまま気付かれず、上記の危険な状態を生んでいた (ワークスペースの変数は 0 件だった)。コードの `default` で管理する方式に改め、README と手順書も修正した。

| 変数 | 変更前 | 変更後 |
|---|---|---|
| `guest_datastore_id` | `local-lvm` | **`local-zfs`** |
| `enable_ha` | `false` | **`true`** |

## 作られるリソース

| 種別 | 件数 | 内容 |
|---|---|---|
| `proxmox_replication` | 5 | dns01 / traefik は 5 分間隔、他は 15 分間隔 |
| `proxmox_haresource` | 5 | `failback = false` / `max_restart = 2` / `max_relocate = 2` |
| `proxmox_harule` | 5 | node-affinity、**`strict = true`** |
| `proxmox_storage_zfspool` | 1 (import) | Phase 1 で `pvesm add` した `local-zfs` を取り込む |

フェイルオーバー設計:

| ゲスト | 通常 | 退避先 | 複製間隔 |
|---|---|---|---|
| dns01 (100) | pve | pve3 | 5 分 |
| pulse (101) | pve | pve3 | 15 分 |
| traefik (102) | pve | pve3 | 5 分 |
| homepage (104) | pve | pve2 | 15 分 |
| gh-runner (105) | pve3 | pve2 | 15 分 |

## 移行の実績

| Phase | 結果 |
|---|---|
| Phase 0 | バックアップ 6 件取得、VM 103 の CD-ROM 取り外し |
| Phase 1 | pve2 → ZFS (`rpool_data` 324G) |
| Phase 2 | pve3 → ZFS (152G)、`ct:105` を復元 |
| Phase 3 | pve → ZFS (352G)、全ゲストを ZFS へ移行して復帰 |

**DNS 断は 22 秒のみ。** VM 103 は ZFS 化後に `--with-local-disks` 付きライブマイグレーションで無停止復帰した。

移行中に判明した手順書の誤りは修正済み。

- `pct` / `qm` はゲストをホストしているノードから実行する必要がある
- **`--target-storage` は LXC・VM とも lvmthin → zfspool の異種間移行に非対応**。`vzdump` + `destroy` + `restore` が必要 (ZFS 化後の ZFS 同士なら通常の migrate が使える)
- `lvcreate` が旧 ext4 シグネチャで対話待ちになるため `-y -Wy` が必須

## apply 後

`imports.tf` は役目を終えるので削除する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)