### PR TITLE
docs(homelab): VM.Replicate 権限の必要性を明記する

### DIFF
--- a/terraform/homelab/README.md
+++ b/terraform/homelab/README.md
@@ -97,7 +97,7 @@ pveum user add terraform@pve
 ```
 
 ```bash
-pveum role add Terraform -privs "Datastore.Allocate,Datastore.AllocateSpace,Datastore.AllocateTemplate,Datastore.Audit,Pool.Allocate,Pool.Audit,SDN.Audit,SDN.Use,Sys.Audit,Sys.Console,Sys.Modify,VM.Allocate,VM.Audit,VM.Clone,VM.Config.CDROM,VM.Config.CPU,VM.Config.Cloudinit,VM.Config.Disk,VM.Config.HWType,VM.Config.Memory,VM.Config.Network,VM.Config.Options,VM.Console,VM.Migrate,VM.PowerMgmt,VM.Snapshot,VM.Snapshot.Rollback"
+pveum role add Terraform -privs "Datastore.Allocate,Datastore.AllocateSpace,Datastore.AllocateTemplate,Datastore.Audit,Pool.Allocate,Pool.Audit,SDN.Audit,SDN.Use,Sys.Audit,Sys.Console,Sys.Modify,VM.Allocate,VM.Audit,VM.Clone,VM.Config.CDROM,VM.Config.CPU,VM.Config.Cloudinit,VM.Config.Disk,VM.Config.HWType,VM.Config.Memory,VM.Config.Network,VM.Config.Options,VM.Console,VM.Migrate,VM.PowerMgmt,VM.Replicate,VM.Snapshot,VM.Snapshot.Rollback"
 ```
 
 ```bash
@@ -108,9 +108,25 @@ pveum aclmod / -user terraform@pve -role Terraform
 pveum user token add terraform@pve provider --privsep=0
 ```
 
-> [!NOTE]
-> HA とレプリケーションを Terraform から管理する際に権限不足なら apply 時に
-> 403 が返る。その時点で `pveum role modify` で権限を足すこと。
+> [!IMPORTANT]
+> **`VM.Replicate` は `pvesr` のレプリケーションジョブ作成に必須。**
+> 当初の権限一覧には含まれておらず、2026-07-26 の HA 有効化 apply が
+> 次のエラーで失敗した。
+>
+> ```
+> error creating Replication: received an HTTP 403 response
+> Reason: Forbidden (Permission check failed (/vms/100, VM.Replicate))
+> ```
+>
+> 既存ロールへ後から足す場合は `--append` を使う (付けないと権限一覧が
+> 置き換わる)。
+>
+> ```bash
+> pveum role modify Terraform --privs VM.Replicate --append 1
+> ```
+>
+> HA リソースとルールの操作には `Sys.Console` が要るが、これは当初から
+> 含まれている。
 
 ### HCP Terraform ワークスペース変数
 


### PR DESCRIPTION
## 問題

[#77](https://github.com/morihaya/morihaya-infra/pull/77) の HA 有効化 apply が、全レプリケーションジョブの作成で 403 になった。

```
error creating Replication: received an HTTP 403 response
Reason: Forbidden (Permission check failed (/vms/100, VM.Replicate))
```

README のロール作成コマンドに `VM.Replicate` が含まれておらず、実機の `Terraform` ロールは 27 権限しか持っていなかった。`pvesr` のレプリケーションジョブ作成にはこの権限が必須。

## 対応

実機のロールには追加済み (27 → 28 権限)。

```bash
pveum role modify Terraform --privs VM.Replicate --append 1
```

README のロール作成コマンドにも `VM.Replicate` を追加し、後から足す際に `--append` を忘れると権限一覧が置き換わってしまう点もあわせて記載した。

HA リソースとルールの操作に必要な `Sys.Console` は当初から含まれていたため追加不要。

## apply の途中経過

エラーで止まったが、部分的には成功している。

| リソース | 結果 |
|---|---|
| `proxmox_storage_zfspool` (import) | ✅ 成功 (`sparse 1` が反映され resource-count 6→7) |
| `proxmox_replication` × 5 | ❌ 403 |
| `proxmox_haresource` × 5 | 未実行 (`depends_on` のため) |
| `proxmox_harule` × 5 | 未実行 |

ワークスペースはロックされておらず、コード側の修正は不要。**HCP で run を再実行すれば通る見込み。**

> [!NOTE]
> 本 PR は README のみの変更で、`trigger_patterns` (`/terraform/homelab/*.tf`) に一致しないため run は自動起動しない。再実行は HCP の UI から手動で行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)