### PR TITLE
chore(homelab): provider 認証情報を env カテゴリ前提にし shim 宣言を削除する

### DIFF
--- a/terraform/homelab/README.md
+++ b/terraform/homelab/README.md
@@ -130,11 +130,22 @@ pveum user token add terraform@pve provider --privsep=0
 
 ### HCP Terraform ワークスペース変数
 
+Homelab variable set (HomeLab プロジェクトに紐付け) に登録する。
+
 | 変数 | 種別 | Sensitive | 説明 |
 |------|------|-----------|------|
-| `PROXMOX_VE_ENDPOINT` | Environment | No | Proxmox API URL |
-| `PROXMOX_VE_API_TOKEN` | Environment | Yes | `terraform@pve!provider=xxx` |
-| `PROXMOX_VE_INSECURE` | Environment | No | 自己署名証明書なら `true` |
+| `PROXMOX_VE_ENDPOINT` | **Environment** | No | Proxmox API URL |
+| `PROXMOX_VE_API_TOKEN` | **Environment** | Yes | `terraform@pve!provider=xxx` |
+| `PROXMOX_VE_INSECURE` | **Environment** | No | 自己署名証明書なら `true` |
+
+> [!IMPORTANT]
+> **種別は Environment。** provider は OS の環境変数として読むため。
+> Terraform 種別にすると「宣言されていない Terraform 変数に値が渡っている」
+> ことになり、plan のたびに `Warning: Value for undeclared variable` が出る。
+>
+> 宣言を足して黙らせることもできるが、provider が使わない変数の
+> `tflint-ignore` 付きダミー宣言が増えるだけになる。実際に 2026-07-26 まで
+> その状態で、`variables.tf` に 3 つのダミー宣言が置かれていた。
 
 ### HCP Terraform Agent
 

--- a/terraform/homelab/variables.tf
+++ b/terraform/homelab/variables.tf
@@ -1,27 +1,16 @@
 # =============================================================================
-# Variables provided by HCP Terraform workspace settings
-# (consumed by the provider via environment variables, not referenced directly)
+# Proxmox provider の認証情報 (PROXMOX_VE_ENDPOINT / PROXMOX_VE_API_TOKEN /
+# PROXMOX_VE_INSECURE) はここで宣言しない。
+#
+# provider は OS の環境変数として読むため、HCP 側では Homelab variable set に
+# Environment カテゴリで登録する。Terraform カテゴリにすると、宣言していない
+# 変数に値が渡ることになり plan のたびに次の警告が出る。
+#
+#   Warning: Value for undeclared variable
+#
+# 宣言を足して黙らせることもできるが、provider が使わない変数の
+# tflint-ignore 付きダミー宣言が増えるだけで、実態も分かりにくくなる。
 # =============================================================================
-# tflint-ignore: terraform_unused_declarations
-variable "PROXMOX_VE_API_TOKEN" {
-  description = "Proxmox VE API token (also consumed by the provider via environment variable)"
-  type        = string
-  sensitive   = true
-}
-
-# tflint-ignore: terraform_unused_declarations
-variable "PROXMOX_VE_ENDPOINT" {
-  description = "Proxmox VE API endpoint URL"
-  type        = string
-}
-
-# tflint-ignore: terraform_unused_declarations
-variable "PROXMOX_VE_INSECURE" {
-  description = "Skip TLS verification when talking to the Proxmox VE API"
-  type        = bool
-  default     = true
-}
-
 # =============================================================================
 # Proxmox Configuration Variables
 # =============================================================================


### PR DESCRIPTION
## 警告の原因

```
Warning: Value for undeclared variable
The root module does not declare a variable named "PROXMOX_DEFAULT_PASSWORD"
but a value was found in file or environment.
```

Homelab variable set の **5 変数が全て `terraform` カテゴリ**で登録されており、うち `PROXMOX_DEFAULT_PASSWORD` と `morihaya_ssh_public_key` は `variables.tf` に宣言が無かった。Terraform は「宣言されていない Terraform 変数に値が来た」と警告する。

## 調査で分かったこと

`PROXMOX_VE_*` の 3 つも**コードから一切参照されていなかった** (`tflint-ignore` 付きのダミー宣言のみ)。宣言を外して plan したところ**成功した**。

```console
$ terraform plan   # shim 宣言を削除した状態
No changes. Your infrastructure matches the configuration.
```

つまり provider はこれらを Terraform 変数としては必要としていない。

ただし**警告は消えない**。宣言を外すと今度はその 3 つが「未宣言」になり、警告の対象が入れ替わるだけだった。

| 状態 | 警告される変数 |
|---|---|
| 現状 (shim あり) | `PROXMOX_DEFAULT_PASSWORD` / `morihaya_ssh_public_key` |
| shim を削除 | `PROXMOX_VE_ENDPOINT` / `PROXMOX_VE_INSECURE` … |

## 対応方針

**`env` カテゴリにすれば警告は原理的に出ない** (環境変数は宣言と照合されないため)。provider が読むのは本来 OS の環境変数なので、そちらが正しい姿でもある。[#69](https://github.com/morihaya/morihaya-infra/pull/69) の `TFE_TOKEN` で選んだ方針とも揃う。

本 PR ではコード側だけを変更する。

- `PROXMOX_VE_*` の shim 宣言 3 件を削除
- なぜ宣言しないのかを `variables.tf` と README に明記

## ⚠️ HCP 側の作業が別途必要

**本 PR 単体をマージしても警告は消えない。** 以下を HCP で行う必要がある。詳細は PR のコメント参照。

1. Homelab varset の未使用 2 変数 (`PROXMOX_DEFAULT_PASSWORD` / `morihaya_ssh_public_key`) を削除
2. `PROXMOX_VE_*` の 3 変数を Environment カテゴリで登録し直す

> [!WARNING]
> 手順 2 を先にやると、`terraform` カテゴリの値が消えた状態でこの PR が未マージだと `No value for required variable` で plan が落ちる。**本 PR をマージしてから HCP の作業を行うこと。**

## 未解明のまま残すこと

agent VM (192.168.1.7) の tfc-agent コンテナの環境変数には `TFC_AGENT_TOKEN` / `TFC_AGENT_NAME` / `PATH` / `BIN_DIR` しか無く、`PROXMOX_VE_*` は存在しない。それにも関わらず shim 宣言を消しても provider は認証できた。HCP が run 実行時に何らかの形で渡していると推測するが、断定はしない。

いずれにせよ `env` カテゴリにすれば意図が明確になり、この曖昧さ自体が解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)