### PR TITLE
fix(pagerduty): UI で変更した対応時間帯の設定をコードへ取り込む

### DIFF
--- a/terraform/pagerduty/pagerduty_service_pulse.tf
+++ b/terraform/pagerduty/pagerduty_service_pulse.tf
@@ -24,8 +24,52 @@ resource "pagerduty_service" "pulse_homelab" {
   # Pulse 側の notifyOnResolve が無効な間、復旧通知が飛んでこないため
   # インシデントはこのタイムアウトで自動クローズされる。
   # Pulse から resolve を送るようにしたらここは短縮してよい。
-  auto_resolve_timeout    = 14400
-  acknowledgement_timeout = 600
+  auto_resolve_timeout = 86400
+
+  # 自宅環境であり、ACK し忘れたからといって再通知で追い立てたくないため無効。
+  #
+  # この属性は型が string で、無効化は HCL の null ではなく文字列 "null" で表す。
+  # HCL の null を書くと「未設定」と解釈され、provider が既定値 1800 を入れる。
+  acknowledgement_timeout = "null"
+
+  # =========================================================================
+  # 対応時間帯による緊急度の出し分け
+  #
+  # 自宅サーバなので、深夜に high で叩き起こされるのを避ける。
+  # 平日 10:00-22:00 (JST) は high、それ以外は low。
+  # 時間外に発生して未解決のまま対応時間に入ったものは high へ昇格させる。
+  # =========================================================================
+  incident_urgency_rule {
+    type = "use_support_hours"
+
+    during_support_hours {
+      type    = "constant"
+      urgency = "high"
+    }
+
+    outside_support_hours {
+      type    = "constant"
+      urgency = "low"
+    }
+  }
+
+  support_hours {
+    type         = "fixed_time_per_day"
+    time_zone    = "Asia/Tokyo"
+    days_of_week = [1, 2, 3, 4, 5]
+    start_time   = "10:00:00"
+    end_time     = "22:00:00"
+  }
+
+  scheduled_actions {
+    type       = "urgency_change"
+    to_urgency = "high"
+
+    at {
+      type = "named_time"
+      name = "support_hours_start"
+    }
+  }
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## 検出したドリフト

`terraform plan` が provider の検証エラーで**通らない状態**だった。

```
Error: when using type = use_support_hours in incident_urgency_rule
you must specify exactly one (otherwise optional) support_hours block
```

`terraform plan -refresh-only` で実際の差分を取得した。

| 項目 | コード | 実機 (UI で変更) |
|---|---|---|
| `auto_resolve_timeout` | `14400` | **`86400`** |
| `acknowledgement_timeout` | `600` | **無効** |
| `incident_urgency_rule.type` | `constant` / `high` | **`use_support_hours`** |
| `support_hours` | なし | **平日 10:00-22:00 / Asia/Tokyo** |
| `scheduled_actions` | なし | **`support_hours_start` に high へ昇格** |

自宅サーバなので深夜に high で叩き起こされるのを避ける意図とのことで、コード側を実機に合わせる。

## `acknowledgement_timeout` の書き方に注意

この属性は**型が `string`** で、無効化は HCL の `null` ではなく**文字列 `"null"`** で表す。HCL の `null` を書くと「未設定」と解釈され、provider が既定値 `1800` を入れてしまう。

```
~ acknowledgement_timeout = "null" -> "1800"   # HCL の null を書いた場合
```

コードにコメントとして残した。

## エスカレーションポリシーのドリフトについて

`pagerduty_escalation_policy.default` の `rule.id` が `P763AHJ` → `PG8G304` に変わっていたが、これは PagerDuty 側でのルール ID 再採番であり**設定内容は同一** (`name` / `num_loops` / ターゲットは全て unchanged)。コード修正は不要で、本 apply で state が追従する。

## 検証

```console
$ terraform -chdir=terraform/pagerduty plan
No changes. Your infrastructure matches the configuration.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)