### PR TITLE
feat(homelab): OpenClaw 執事エージェント用の VM 106 を追加する

### DIFF
--- a/docs/openclaw-butler-handover.md
+++ b/docs/openclaw-butler-handover.md
@@ -1,8 +1,37 @@
 # OpenClaw 自宅執事エージェント構築 — 引き継ぎ計画書
 
 - 作成: 2026-07-29(Claude Fable 5 セッションからの引き継ぎ用)
+- 更新: 2026-07-30(Phase 1 マージ済み、Phase 2 の VM コード化まで完了)
 - 目的: Proxmox 環境に OpenClaw を導入し、家族用 Slack に常駐する執事型 AI エージェントを構築する
-- 状態: **設計・AWS 側 Terraform 実装まで完了(未コミット)**。以降の作業をこのドキュメントに従って進める
+- 状態: **AWS 側は #84 でマージ済み。Proxmox VM 側 (Phase 2) は別 PR で実装中**
+
+## 0. 現在の進捗
+
+| Phase | 状態 | 補足 |
+|---|---|---|
+| 1. AWS 土台 | **コードは #84 でマージ済み** | plan は `3 added`。auto-apply 無効なので main の run を HCP UI で Confirm & Apply する |
+| 2. VM 構築 | **コード実装済み・apply 前** | `terraform/homelab/106vm_openclaw.tf`、HA 登録込み |
+| 3. OpenClaw セットアップ | 未着手 | VM 起動後 |
+| 4. 執事化・運用 | 未着手 | |
+
+> [!NOTE]
+> Phase 1 と Phase 2 は当初 1 つの PR にまとめていたが、#84 が AWS 分だけの
+> 状態でマージされたため、Phase 2 は別ブランチの PR に切り出した。
+> ワークスペースが別 (`aws-root` / `homelab`) なので分けるほうが plan も読みやすい。
+
+### Phase 2 で確定した仕様(2026-07-30 にユーザー判断)
+
+当初案の 4vCPU/8GB は**クラスタの物理メモリに収まらない**ことが判明したため見直した。
+`pve` は既に約 8.3GB/16GB 使用済み、`pve3` は 8GB しかない。OpenClaw の推論は
+すべて Bedrock 側なのでローカル資源はほぼ不要で、8GB は「ブラウザ自動化を使う場合」の数字。
+
+| 項目 | 決定 |
+|---|---|
+| スペック | **2vCPU / 4GB / 40GB**(ブラウザ自動化なし前提) |
+| 配置ノード | **pve3**(105 のみで最も空きがある) |
+| 作成方法 | **Terraform で新規作成**(Debian 12 genericcloud + cloud-init) |
+| IP | **192.168.1.12/24** 固定 |
+| HA | primary `pve3` / standby **`pve`**(pve2 は 104+105 の standby 兼任で容量不足) |
 
 ## 1. 決定事項とその理由
 
@@ -34,15 +63,21 @@
 ## 3. 残作業(推奨順)
 
 ### Phase 1: AWS 土台の反映
-1. ブランチを切り、上記変更をコミット・push・PR(コミット規約: `feat(aws): ...` 形式・日本語、直近の git log 参照)
-2. HCP Terraform の run を **confirm まで**確認(過去に confirm 忘れでワークスペースが長期ロックされた事故あり)
-3. apply 後、コンソールか `aws iam create-access-key --user-name openclaw-butler` でアクセスキー発行
-4. Bedrock コンソール(ap-northeast-1)で Anthropic モデルの Model access を有効化(忘れると 403)
+1. ~~ブランチを切り、上記変更をコミット・push・PR~~ → **完了。#84 としてマージ済み**
+2. **[要対応] main の run を Confirm & Apply する**。plan は `3 added, 0 changed, 0 destroyed` で意図どおり。auto-apply は無効なので UI 操作が必須(過去に confirm 忘れでワークスペースが長期ロックされた事故あり)
+3. **[要対応] アクセスキーを発行する**。この Mac に AWS の認証情報が無いため CLI からは実行できない。コンソールか `aws iam create-access-key --user-name openclaw-butler`
+4. **[要対応] Bedrock コンソール(ap-northeast-1)で Anthropic モデルの Model access を有効化**(忘れると 403)
 
 ### Phase 2: VM 構築(Proxmox)
-1. Debian 12 VM(4vCPU/8GB/40GB〜)を作成。既存の ZFS + pvesr レプリケーション対象に載せる(HA 設計は別途メモリ/ドキュメント参照)
-2. Docker Engine + Compose v2 導入
-3. FW/VLAN: outbound のみ許可。NAS・Proxmox 管理面への到達は遮断。inbound は全閉じ(Socket Mode のため不要)
+
+コードは実装済み(`terraform/homelab/106vm_openclaw.tf` + `ha.tf` の VM 対応)。残りは以下。
+
+1. **apply 前に `192.168.1.12` が空いていることを確認する**。既存ゲストは .4/.5/.6/.8/.9 を使用し .7 は用途不明のため .12 を選定した。AdGuard Home(LXC 100)の DHCP プール範囲外であることも併せて確認し、必要なら予約する
+2. homelab ワークスペースの apply を実行(HCP Agent 実行 = VM 103 経由)
+3. cloud image のダウンロードは初回 apply 時に pve3 の `local` へ行われる。`import` content type ではなく `iso` として保存しているため、datastore の content 設定変更は不要
+4. VM 起動後 SSH(`morihaya@192.168.1.12`、鍵は ansible の common ロールと共用)→ Docker Engine + Compose v2 導入
+5. `qemu-guest-agent` を導入(cloud image に同梱されていないため、入れてから `agent` ブロックを有効化する)。ansible の common ロール適用も併せて行う
+6. FW/VLAN: outbound のみ許可。NAS・Proxmox 管理面への到達は遮断。inbound は全閉じ(Socket Mode のため不要)
 
 ### Phase 3: OpenClaw セットアップ
 1. 公式 docker-compose で起動、`.env` に `AWS_REGION=ap-northeast-1` とアクセスキー

--- a/terraform/homelab/106vm_openclaw.tf
+++ b/terraform/homelab/106vm_openclaw.tf
@@ -1,0 +1,139 @@
+# =============================================================================
+# Virtual Machine 106 - OpenClaw (自宅 Slack 常駐の執事エージェント)
+#
+# 構築計画の全体は リポジトリ直下の docs/openclaw-butler-handover.md を参照。
+#
+# 【LXC ではなく VM にする理由】
+# OpenClaw はエージェント自身がシェルを実行できる。プロンプトインジェクション
+# で意図しないコマンドを走らされた場合の影響を、カーネルを共有しない VM の
+# 境界で止めたいため。他のゲストが LXC なのに対しここだけ VM にしている。
+#
+# 【スペックの根拠】
+# 公式の推奨は 4vCPU/8GB だが、それはブラウザ自動化 (Chromium 同梱) を使う
+# 場合の数字。推論はすべて Amazon Bedrock 側で行うためローカルの計算資源は
+# ほぼ不要で、ブラウザ自動化なしなら 2vCPU/4GB で足りる。
+# クラスタのメモリにも余裕が無く、8GB を積むと ha.tf のフェイルオーバー
+# 収容計算が破綻する (pve3 は 8GB しか無い)。
+#
+# 【既存ゲストとの違い】
+# 100-105 は手動作成したものを import した経緯があり initialization と
+# operating_system が ignore_changes に入っている。この 106 は Terraform で
+# 新規作成するため ignore_changes に入れない (cloud-init の設定をコードで
+# 管理し続ける)。
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Debian 12 (bookworm) の cloud image
+# ゲストディスクと違いノードローカルの `local` に置く。レプリケーション対象では
+# ないが、VM 作成時に import 元として一度読むだけなので複製は不要。
+# -----------------------------------------------------------------------------
+resource "proxmox_download_file" "debian12_genericcloud" {
+  node_name    = "pve3"
+  datastore_id = "local"
+  content_type = "iso"
+
+  # qcow2 のままだと content_type = "iso" が受け付けないため .img で保存する
+  file_name = "debian-12-genericcloud-amd64.img"
+  url       = "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+
+  # latest は中身が更新され続けるためチェックサム検証は行わない。
+  # 検証したい場合は同ディレクトリの SHA512SUMS から値を取って
+  # checksum / checksum_algorithm を指定する。
+  overwrite = false
+}
+
+resource "proxmox_virtual_environment_vm" "vm_106" {
+  node_name   = "pve3"
+  vm_id       = 106
+  name        = "openclaw"
+  description = "OpenClaw butler agent (Slack + Amazon Bedrock) - Managed by Terraform"
+
+  started         = true
+  on_boot         = true
+  stop_on_destroy = true
+
+  cpu {
+    cores   = 2
+    sockets = 1
+    type    = "x86-64-v2-AES"
+    numa    = false
+  }
+
+  memory {
+    dedicated = 4096
+  }
+
+  # ブートディスク。cloud image を import して 40GB へ拡張する。
+  # OpenClaw のイメージは 2-4GB 程度だが、会話履歴とメモリが育つため余裕を持たせる。
+  disk {
+    datastore_id = var.guest_datastore_id
+    import_from  = proxmox_download_file.debian12_genericcloud.id
+    interface    = "scsi0"
+    size         = 40
+    iothread     = true
+  }
+
+  # cloud-init
+  initialization {
+    datastore_id = var.guest_datastore_id
+
+    ip_config {
+      ipv4 {
+        address = "192.168.1.12/24"
+        gateway = "192.168.1.1"
+      }
+    }
+
+    user_account {
+      username = "morihaya"
+      # ansible 側と鍵の実体を二重管理しないよう、common ロールの
+      # authorized_keys をそのまま読む。先頭のコメント行は除外する。
+      keys = [
+        for line in split("\n", trimspace(file("${path.module}/../../ansible/roles/common/keys/authorized_keys.morihaya"))) :
+        trimspace(line) if length(trimspace(line)) > 0 && !startswith(trimspace(line), "#")
+      ]
+    }
+  }
+
+  network_device {
+    bridge   = "vmbr0"
+    model    = "virtio"
+    firewall = true
+  }
+
+  bios          = "seabios"
+  scsi_hardware = "virtio-scsi-single"
+  machine       = "pc"
+  boot_order    = ["scsi0"]
+
+  operating_system {
+    type = "l26"
+  }
+
+  # QEMU Guest Agent は Debian の genericcloud イメージに同梱されていないため
+  # 有効化しない (有効にすると provider が起動時にエージェント応答を待ち続ける)。
+  # 導入後に ansible で qemu-guest-agent を入れてから有効化する。
+
+  startup {
+    down_delay = -1
+    order      = 99
+    up_delay   = -1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      node_name, # HA によるフェイルオーバー先を Terraform で巻き戻さない
+    ]
+  }
+}
+
+## Output Values
+output "vm_106_vm_id" {
+  description = "VM ID of the OpenClaw butler agent VM"
+  value       = proxmox_virtual_environment_vm.vm_106.vm_id
+}
+
+output "vm_106_ipv4" {
+  description = "Static IPv4 address of the OpenClaw butler agent VM (cloud-init assigned)"
+  value       = "192.168.1.12"
+}

--- a/terraform/homelab/README.md
+++ b/terraform/homelab/README.md
@@ -27,6 +27,7 @@
 | 103 | VM  | hcp-terraform-agent | DHCP | pve | HCP Terraform Agent |
 | 104 | LXC | homepage | 192.168.1.8 | pve | ダッシュボード |
 | 105 | LXC | gh-runner | 192.168.1.9 | pve3 | GitHub Actions セルフホストランナー |
+| 106 | VM  | openclaw | 192.168.1.12 | pve3 | OpenClaw 執事エージェント (Slack + Bedrock) |
 
 ## High Availability
 
@@ -68,6 +69,7 @@ homelab/
 ├── 103vm_hcp_terraform_agent.tf
 ├── 104lxc_homepage.tf
 ├── 105lxc_gh_runner.tf
+├── 106vm_openclaw.tf              # 唯一 Terraform で新規作成した VM (cloud-init)
 └── docs/
     └── zfs-ha-migration.md        # ZFS 移行と HA 有効化の手順書
 ```
@@ -86,7 +88,11 @@ homelab/
   変数変更は必ずセットで行う。
 - `initialization` と `operating_system` は手動作成のコンテナを import した
   経緯から `ignore_changes` に入っている。IP を変えたい場合は Proxmox 側で
-  変更すること。
+  変更すること。**ただし 106 は Terraform で新規作成したため対象外**で、
+  cloud-init の設定はコードが正となる。
+- HA リソース ID には `ct:` / `vm:` の種別プレフィックスが必要。
+  `local.ha_guests` の `type` は省略時 `ct` として扱うため、LXC のエントリには
+  書かない (106 のみ `type = "vm"`)。
 
 ## Prerequisites
 

--- a/terraform/homelab/ha.tf
+++ b/terraform/homelab/ha.tf
@@ -16,9 +16,17 @@
 #
 # 【フェイルオーバー時のメモリ収容】
 #   pve 障害時  -> pve3 が 100/101/102 (計 2.0GB) を引き取る。pve3 は自分の
-#                  105 (2GB) と合わせて 4.0GB / 8GB で収まる。
+#                  105 (2GB) と 106 (4GB) と合わせて 8.0GB / 8GB。上限に張り付く
+#                  ため、この状態が続く場合は 106 を手動で pve2 へ寄せる。
 #                  pve2 が 104 (4GB) を引き取り 4.0GB / 7.5GB。
-#   pve3 障害時 -> pve2 が 105 (2GB) を引き取る。
+#   pve3 障害時 -> pve2 が 105 (2GB) を引き取り、pve が 106 (4GB) を引き取る。
+#                  pve は 100-104 と 103 で約 8.3GB 使用しており 12.3GB / 16GB。
+#
+# 【種別 (ct / vm)】
+# HA リソース ID は `ct:100` / `vm:106` のように種別のプレフィックスが要る。
+# 既存ゲストは全て LXC なので type を省略した場合は "ct" とみなす
+# (省略時の既定値を "ct" にすることで、106 追加時に既存 5 件の plan を
+# no-op に保っている)。
 #
 # 【データ欠損】レプリケーションは非同期のため、障害時は最大で schedule
 # 間隔ぶんの書き込みが失われる。DNS/DHCP と Traefik は 5 分、
@@ -68,9 +76,25 @@ locals {
       standby  = "pve2"
       schedule = "*/15"
     }
+    # 唯一の VM。standby は pve2 ではなく pve にする。pve2 は 104 (4GB) と
+    # 105 (2GB) の standby を既に兼ねており、7.5GB では 106 の 4GB を
+    # 追加で収容できないため。
+    106 = {
+      name     = "openclaw"
+      type     = "vm"
+      primary  = "pve3"
+      standby  = "pve"
+      schedule = "*/15"
+    }
   }
 
   ha_guests_enabled = var.enable_ha ? local.ha_guests : {}
+
+  # ha_guests の各エントリに種別を補完したもの (省略時は LXC)
+  ha_guest_ids = {
+    for id, g in local.ha_guests_enabled :
+    id => "${lookup(g, "type", "ct")}:${id}"
+  }
 }
 
 # -----------------------------------------------------------------------------
@@ -122,7 +146,7 @@ resource "proxmox_replication" "guest" {
 resource "proxmox_haresource" "guest" {
   for_each = local.ha_guests_enabled
 
-  resource_id = "ct:${each.key}"
+  resource_id = local.ha_guest_ids[each.key]
   state       = "started"
 
   # 復旧したノードへ自動的に戻さない。戻す動作は 2 回目の短時間停止を生むため、
@@ -146,7 +170,7 @@ resource "proxmox_harule" "node_affinity" {
 
   rule      = "node-affinity-${each.value.name}"
   type      = "node-affinity"
-  resources = ["ct:${each.key}"]
+  resources = [local.ha_guest_ids[each.key]]
 
   # 複製を持つ 2 ノード以外では絶対に起動させない
   strict = true
@@ -171,6 +195,6 @@ output "ha_failover_map" {
   description = "Failover target and replication interval for each HA-managed guest"
   value = {
     for id, g in local.ha_guests :
-    g.name => "ct:${id} ${g.primary} -> ${g.standby} (every ${g.schedule})"
+    g.name => "${lookup(g, "type", "ct")}:${id} ${g.primary} -> ${g.standby} (every ${g.schedule})"
   }
 }


### PR DESCRIPTION
## 概要

Slack に常駐する OpenClaw 執事エージェントを載せる VM を Terraform で新規作成する。
AWS 側 (Bedrock 権限・予算) は #84 でマージ済みで、これはその続きの Phase 2。

構築計画の全体は [docs/openclaw-butler-handover.md](docs/openclaw-butler-handover.md) を参照。

## 変更内容

- **`106vm_openclaw.tf` (新規)**: Debian 12 genericcloud + cloud-init による VM (pve3, 192.168.1.12)
  - **2vCPU / 4GB / 40GB**。公式推奨の 4vCPU/8GB はブラウザ自動化 (Chromium 同梱) を使う場合の値で、推論は Bedrock 側なのでローカル資源はほぼ不要。8GB は pve3 の物理メモリ (8GB) に収まらず、`ha.tf` のフェイルオーバー収容計算も破綻する
  - エージェント自身がシェルを実行できるため、他ゲストと違い LXC ではなく **VM で隔離**する
  - 既存ゲストは手動作成からの import で `initialization` が `ignore_changes` に入っているが、**この 106 は cloud-init までコード管理**する
- **`ha.tf`**: HA リソース ID の種別プレフィックス (`ct:` / `vm:`) に対応
  - `local.ha_guests` の `type` は省略時 `ct` として扱うため、**既存 5 件の plan は no-op**。`terraform console` で `ct:100` 等が従来と同一文字列になることを確認済み
  - 106 の standby は pve2 ではなく **pve**。pve2 は 104 (4GB) と 105 (2GB) の standby を兼ねており 7.5GB では 106 の 4GB を収容できない
  - フェイルオーバー時のメモリ収容計算をコメントに反映
- **`README.md`**: 管理対象ゲスト表・ファイル構成・約束ごとを更新

## 確認事項

- `terraform fmt` / `validate` / `tflint` 通過済み
- **apply 前に `192.168.1.12` が空いていることを確認**すること。既存ゲストは .4/.5/.6/.8/.9 を使用し、.7 は用途不明のため .12 を選定した。AdGuard Home (LXC 100) の DHCP プール範囲外であることも確認し、必要なら予約する
- cloud image は初回 apply 時に pve3 の `local` へダウンロードされる。`import` ではなく `iso` content type で保存するため datastore の content 設定変更は不要
- `qemu-guest-agent` は cloud image に同梱されていないため `agent` ブロックは無効のまま。apply 後に ansible で導入してから有効化する

🤖 Generated with [Claude Code](https://claude.com/claude-code)