### PR TITLE
fix(homelab): cloud image を import タイプのストレージへ置く

### DIFF
--- a/docs/openclaw-butler-handover.md
+++ b/docs/openclaw-butler-handover.md
@@ -90,12 +90,13 @@
 > 順序の問題も `depends_on` で直した(詳細は
 > [terraform/homelab/README.md](../terraform/homelab/README.md) の約束ごと)。
 >
-> **再 apply 前に確認すること**: 失敗した apply の残骸。
-> - `local` に残った `debian-12-genericcloud-amd64.img`(約 350MB)。
->   `proxmox_download_file` が state にあれば置き換え時に削除されるが、
->   state に無い場合は手動削除が必要
-> - レプリケーションジョブ `106-0` や HA リソース `vm:106` が中途半端に
->   作られていないか。plan の差分で確認する
+> **失敗した apply の残骸は無い**(修正 PR の plan `6 to add, 0 to change,
+> 1 to destroy` で確認済み)。
+> - `1 to destroy` は `proxmox_download_file` の置き換え。古いリソースが
+>   state にあるため、`local` に残った `.img`(約 350MB)は apply 時に
+>   自動削除される。手動削除は不要
+> - VM・レプリケーションジョブ `106-0`・HA リソース `vm:106` はいずれも
+>   state に無い。VM 作成が最初に失敗したため後続は作られていない
 4. VM 起動後 SSH(`morihaya@192.168.1.12`、鍵は ansible の common ロールと共用)→ Docker Engine + Compose v2 導入
 5. `qemu-guest-agent` を導入(cloud image に同梱されていないため、入れてから `agent` ブロックを有効化する)。ansible の common ロール適用も併せて行う
 6. FW/VLAN: outbound のみ許可。NAS・Proxmox 管理面への到達は遮断。inbound は全閉じ(Socket Mode のため不要)

--- a/docs/openclaw-butler-handover.md
+++ b/docs/openclaw-butler-handover.md
@@ -74,7 +74,28 @@
 
 1. **apply 前に `192.168.1.12` が空いていることを確認する**。既存ゲストは .4/.5/.6/.8/.9 を使用し .7 は用途不明のため .12 を選定した。AdGuard Home(LXC 100)の DHCP プール範囲外であることも併せて確認し、必要なら予約する
 2. homelab ワークスペースの apply を実行(HCP Agent 実行 = VM 103 経由)
-3. cloud image のダウンロードは初回 apply 時に pve3 の `local` へ行われる。`import` content type ではなく `iso` として保存しているため、datastore の content 設定変更は不要
+3. cloud image は初回 apply 時に専用の `image-import` ストレージ(pve3 の `/var/lib/pve-image-import`)へダウンロードされる。ディレクトリごと Terraform が作るので事前準備は不要
+
+> [!WARNING]
+> **1 回目の apply は失敗している(2026-07-30)。** cloud image を `local` に
+> `iso` タイプで置いていたため、ディスクの `import_from` が次のエラーで拒否された。
+>
+> ```
+> scsi0: local:iso/debian-12-genericcloud-amd64.img has wrong type 'iso'
+> - needs to be 'images' or 'import'
+> ```
+>
+> 専用の `import` タイプストレージを新設して修正済み。併せて、Terraform が
+> 同じ apply 内で作るゲストに対してレプリケーションジョブが並行実行される
+> 順序の問題も `depends_on` で直した(詳細は
+> [terraform/homelab/README.md](../terraform/homelab/README.md) の約束ごと)。
+>
+> **再 apply 前に確認すること**: 失敗した apply の残骸。
+> - `local` に残った `debian-12-genericcloud-amd64.img`(約 350MB)。
+>   `proxmox_download_file` が state にあれば置き換え時に削除されるが、
+>   state に無い場合は手動削除が必要
+> - レプリケーションジョブ `106-0` や HA リソース `vm:106` が中途半端に
+>   作られていないか。plan の差分で確認する
 4. VM 起動後 SSH(`morihaya@192.168.1.12`、鍵は ansible の common ロールと共用)→ Docker Engine + Compose v2 導入
 5. `qemu-guest-agent` を導入(cloud image に同梱されていないため、入れてから `agent` ブロックを有効化する)。ansible の common ロール適用も併せて行う
 6. FW/VLAN: outbound のみ許可。NAS・Proxmox 管理面への到達は遮断。inbound は全閉じ(Socket Mode のため不要)

--- a/terraform/homelab/106vm_openclaw.tf
+++ b/terraform/homelab/106vm_openclaw.tf
@@ -23,17 +23,46 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
+# cloud image を置くための import 用ストレージ
+#
+# 【なぜ local を使わないか】
+# 当初は `local` に content_type = "iso" でダウンロードしたが、VM 作成が
+# 次のエラーで失敗した。
+#
+#   scsi0: local:iso/debian-12-genericcloud-amd64.img has wrong type 'iso'
+#   - needs to be 'images' or 'import'
+#
+# ディスクの import 元は `images` か `import` タイプのストレージに無ければ
+# ならない (PVE 8.4 以降で追加された `import` コンテンツタイプ)。`local` に
+# `import` を足すこともできるが、`local` はクラスタ全ノードの ISO・バックアップ・
+# コンテナテンプレートを抱えているため Terraform 管理下に import したくない。
+# 影響範囲を切り離すため専用ストレージを新設する。
+# -----------------------------------------------------------------------------
+resource "proxmox_storage_directory" "image_import" {
+  id      = "image-import"
+  path    = "/var/lib/pve-image-import"
+  content = ["import"]
+
+  # cloud image を読むのは VM 作成時の pve3 だけなので他ノードには広げない
+  nodes = ["pve3"]
+
+  # ディレクトリと配下の import/ を PVE 側に作らせる
+  create_base_path = true
+  create_subdirs   = true
+}
+
+# -----------------------------------------------------------------------------
 # Debian 12 (bookworm) の cloud image
-# ゲストディスクと違いノードローカルの `local` に置く。レプリケーション対象では
-# ないが、VM 作成時に import 元として一度読むだけなので複製は不要。
+# ゲストディスク (local-zfs) と違いレプリケーション対象ではないが、VM 作成時に
+# import 元として一度読むだけなので複製は不要。
 # -----------------------------------------------------------------------------
 resource "proxmox_download_file" "debian12_genericcloud" {
   node_name    = "pve3"
-  datastore_id = "local"
-  content_type = "iso"
+  datastore_id = proxmox_storage_directory.image_import.id
+  content_type = "import"
 
-  # qcow2 のままだと content_type = "iso" が受け付けないため .img で保存する
-  file_name = "debian-12-genericcloud-amd64.img"
+  # import タイプは qcow2 をそのまま扱えるため拡張子の付け替えは不要
+  file_name = "debian-12-genericcloud-amd64.qcow2"
   url       = "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
 
   # latest は中身が更新され続けるためチェックサム検証は行わない。

--- a/terraform/homelab/README.md
+++ b/terraform/homelab/README.md
@@ -93,6 +93,22 @@ homelab/
 - HA リソース ID には `ct:` / `vm:` の種別プレフィックスが必要。
   `local.ha_guests` の `type` は省略時 `ct` として扱うため、LXC のエントリには
   書かない (106 のみ `type = "vm"`)。
+- **ディスクの `import_from` は `images` か `import` タイプのストレージにある
+  ファイルしか受け付けない。** `local` に content_type = `iso` で置いた cloud
+  image を指定すると apply が次のエラーで失敗する。
+  ```
+  scsi0: local:iso/debian-12-genericcloud-amd64.img has wrong type 'iso'
+  - needs to be 'images' or 'import'
+  ```
+  そのため cloud image は専用の `image-import` ストレージ
+  ([106vm_openclaw.tf](106vm_openclaw.tf) の `proxmox_storage_directory`) に
+  `import` タイプで置いている。`local` に `import` を足す手もあるが、`local` は
+  全ノードの ISO・バックアップ・コンテナテンプレートを抱えているため
+  Terraform 管理下に取り込まない。
+- **Terraform が新規作成するゲストを HA に載せる場合、`ha.tf` の
+  `proxmox_replication` に `depends_on` を足す。** 依存が無いとゲスト作成と
+  並行してレプリケーションジョブ作成が走り「そんなゲストは無い」で失敗する。
+  100-105 は import 済みで常に存在していたため露呈していなかった。
 
 ## Prerequisites
 

--- a/terraform/homelab/ha.tf
+++ b/terraform/homelab/ha.tf
@@ -113,6 +113,14 @@ resource "proxmox_storage_zfspool" "guest_storage" {
 
 # -----------------------------------------------------------------------------
 # ストレージレプリケーション (pvesr)
+#
+# 【VM 106 への依存】
+# 100-105 は Terraform の外で作られたものを import したため、レプリケーション
+# ジョブを作る時点でゲストは必ず存在していた。一方 106 は Terraform が同じ
+# apply 内で作るので、depends_on を書かないとゲスト作成と並行して
+# ジョブ作成が走り「そんなゲストは無い」で失敗する。
+# for_each ごとに依存を変えられないため、全ジョブが 106 の作成を待つ。
+# 106 は一度作られるだけなので、これによる遅延は実質ない。
 # -----------------------------------------------------------------------------
 resource "proxmox_replication" "guest" {
   for_each = local.ha_guests_enabled
@@ -137,7 +145,10 @@ resource "proxmox_replication" "guest" {
     ignore_changes = [target]
   }
 
-  depends_on = [proxmox_storage_zfspool.guest_storage]
+  depends_on = [
+    proxmox_storage_zfspool.guest_storage,
+    proxmox_virtual_environment_vm.vm_106,
+  ]
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

#85 のマージ後、homelab の apply が次のエラーで失敗したため修正する。

```
Error: VM create
  with proxmox_virtual_environment_vm.vm_106
  on 106vm_openclaw.tf line 45

All attempts fail:
#1: error creating VM: received an HTTP 400 response - Reason: Bad Request
(scsi0: local:iso/debian-12-genericcloud-amd64.img has wrong type 'iso'
 - needs to be 'images' or 'import' - Parameter verification failed.)
```

ディスクの `import_from` は **`images` か `import` タイプのストレージにあるファイルしか受け付けない**。`local` に `iso` タイプで置いた cloud image を指定していたのが原因。

## 変更内容

- **cloud image 用に `image-import` ストレージを新設** (pve3 の `/var/lib/pve-image-import`、`content = ["import"]`)。`create_base_path` / `create_subdirs` でディレクトリごと Terraform が作るため事前準備は不要
  - `local` に `import` を足す手もあるが、`local` は全ノードの ISO・バックアップ・コンテナテンプレートを抱えているため **Terraform 管理下に取り込まない**方針とした
- `content_type = "import"` に変更。import タイプは qcow2 をそのまま扱えるため、**拡張子を `.img` に付け替える回避策をやめた**
- **`proxmox_replication` に `depends_on` を追加**(併せて見つかった別の順序問題)
  - 100-105 は Terraform の外で作られたものを import したため、ジョブ作成時にゲストは必ず存在していた
  - 106 は同じ apply 内で作るので、依存が無いとゲスト作成と並行してジョブ作成が走り「そんなゲストは無い」で失敗し得る
  - `haresource` → `harule` は `replication` に依存しているため、この 1 箇所で連鎖的に解決する
- 原因と対処を [terraform/homelab/README.md](terraform/homelab/README.md) の約束ごとと [引き継ぎ計画書](docs/openclaw-butler-handover.md) に記録

## plan 結果: `6 to add, 0 to change, 1 to destroy`

失敗した apply の**残骸は無い**ことがこの plan で確認できた。

| 種別 | 内容 |
|---|---|
| destroy 1 | `proxmox_download_file` の置き換え。古いリソースが state にあるため、`local` に残った `.img` (約 350MB) は apply 時に**自動削除される**(手動削除は不要) |
| add 6 | `image-import` ストレージ / 新 `download_file` / VM 106 / レプリケーション `106-0` / HA リソース `vm:106` / node-affinity ルール |
| change 0 | 既存ゲスト 100-105 には引き続き一切触れない |

VM・レプリケーションジョブ・HA リソースが add 側にあることから、いずれも state に無い = VM 作成が最初に失敗したため後続は作られていないことが分かる。

## 確認事項

- `terraform fmt` / `validate` / `tflint` 通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)