### PR TITLE
fix(homelab): 削除できない旧 cloud image を destroy せず state から外す

### DIFF
--- a/docs/openclaw-butler-handover.md
+++ b/docs/openclaw-butler-handover.md
@@ -90,13 +90,40 @@
 > 順序の問題も `depends_on` で直した(詳細は
 > [terraform/homelab/README.md](../terraform/homelab/README.md) の約束ごと)。
 >
-> **失敗した apply の残骸は無い**(修正 PR の plan `6 to add, 0 to change,
-> 1 to destroy` で確認済み)。
-> - `1 to destroy` は `proxmox_download_file` の置き換え。古いリソースが
->   state にあるため、`local` に残った `.img`(約 350MB)は apply 時に
->   自動削除される。手動削除は不要
-> - VM・レプリケーションジョブ `106-0`・HA リソース `vm:106` はいずれも
->   state に無い。VM 作成が最初に失敗したため後続は作られていない
+> VM・レプリケーションジョブ `106-0`・HA リソース `vm:106` は state に無い
+> (修正 PR の plan で add 側だったため)。VM 作成が最初に失敗したため
+> 後続は作られていない。
+
+> [!CAUTION]
+> **2 回目の apply も失敗した(2026-07-30)。旧 cloud image の削除だけは
+> 人間が手を動かす必要がある。**
+>
+> ```
+> Error: Error deleting datastore file
+> Could not delete datastore file 'local:iso/debian-12-genericcloud-amd64.img'
+> ... received an HTTP 400 response - Reason: Bad Request
+> ```
+>
+> `local` → `image-import` への移動は Terraform 上「置き換え」になるが、その
+> destroy が PVE 側で拒否される。PVE は content_type ごとにファイル名と拡張子を
+> 検証しており、`iso` 配下の `.img` は削除 API でも弾かれる。
+> **API 経由では消せないので Terraform には忘れさせるしかない。**
+>
+> コード側は `removed` ブロック(`destroy = false`)+ リソース名変更
+> (`debian12_genericcloud` → `debian12_import`)で対処済み。
+> 残りは以下を pve3 上で手動実行する。
+>
+> ```bash
+> ssh root@192.168.1.11 'ls -la /var/lib/vz/template/iso/'
+> ```
+>
+> ```bash
+> ssh root@192.168.1.11 'rm -i /var/lib/vz/template/iso/debian-12-genericcloud-amd64.img'
+> ```
+>
+> ファイルが既に無い場合もある(その場合 400 の原因は「存在しないファイルの
+> 削除」側)。どちらでも `removed` ブロックで apply は進む。
+> state から外れたことを確認したら `removed` ブロックは削除してよい。
 4. VM 起動後 SSH(`morihaya@192.168.1.12`、鍵は ansible の common ロールと共用)→ Docker Engine + Compose v2 導入
 5. `qemu-guest-agent` を導入(cloud image に同梱されていないため、入れてから `agent` ブロックを有効化する)。ansible の common ロール適用も併せて行う
 6. FW/VLAN: outbound のみ許可。NAS・Proxmox 管理面への到達は遮断。inbound は全閉じ(Socket Mode のため不要)

--- a/terraform/homelab/106vm_openclaw.tf
+++ b/terraform/homelab/106vm_openclaw.tf
@@ -52,11 +52,40 @@ resource "proxmox_storage_directory" "image_import" {
 }
 
 # -----------------------------------------------------------------------------
+# 旧 cloud image (local:iso/debian-12-genericcloud-amd64.img) を
+# destroy せずに state から外す
+#
+# `local` から `image-import` へ移す変更は Terraform 上は「置き換え」になるが、
+# その destroy が次のエラーで失敗し apply が止まった。
+#
+#   Error: Error deleting datastore file
+#   Could not delete datastore file 'local:iso/debian-12-genericcloud-amd64.img'
+#   ... received an HTTP 400 response - Reason: Bad Request
+#
+# PVE は content_type ごとにファイル名と拡張子を検証しており、`iso` 配下の
+# `.img` は削除 API でも弾かれる (bpg プロバイダ側でも既知: ファイルが存在
+# しない場合の destroy 失敗を含む)。API 経由では消せないため、Terraform には
+# 「忘れさせる」だけにしてファイルの後片付けはノード上で手動で行う。
+#
+# この removed ブロックは state から外れたことを確認したら削除してよい。
+# -----------------------------------------------------------------------------
+removed {
+  from = proxmox_download_file.debian12_genericcloud
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+# -----------------------------------------------------------------------------
 # Debian 12 (bookworm) の cloud image
 # ゲストディスク (local-zfs) と違いレプリケーション対象ではないが、VM 作成時に
 # import 元として一度読むだけなので複製は不要。
+#
+# 上記の removed ブロックと同時に成立させるためリソース名を変えている
+# (同じアドレスのままでは「置き換え = destroy が走る」ため)。
 # -----------------------------------------------------------------------------
-resource "proxmox_download_file" "debian12_genericcloud" {
+resource "proxmox_download_file" "debian12_import" {
   node_name    = "pve3"
   datastore_id = proxmox_storage_directory.image_import.id
   content_type = "import"
@@ -96,7 +125,7 @@ resource "proxmox_virtual_environment_vm" "vm_106" {
   # OpenClaw のイメージは 2-4GB 程度だが、会話履歴とメモリが育つため余裕を持たせる。
   disk {
     datastore_id = var.guest_datastore_id
-    import_from  = proxmox_download_file.debian12_genericcloud.id
+    import_from  = proxmox_download_file.debian12_import.id
     interface    = "scsi0"
     size         = 40
     iothread     = true

--- a/terraform/homelab/README.md
+++ b/terraform/homelab/README.md
@@ -105,6 +105,17 @@ homelab/
   `import` タイプで置いている。`local` に `import` を足す手もあるが、`local` は
   全ノードの ISO・バックアップ・コンテナテンプレートを抱えているため
   Terraform 管理下に取り込まない。
+- **`iso` 配下に置いた `.img` は削除 API でも弾かれる。** PVE は content_type
+  ごとにファイル名と拡張子を検証するため、`local:iso/*.img` を Terraform に
+  destroy させると次のエラーで apply が止まる。
+  ```
+  Error: Error deleting datastore file
+  Could not delete datastore file 'local:iso/debian-12-genericcloud-amd64.img'
+  ... received an HTTP 400 response - Reason: Bad Request
+  ```
+  API 経由では消せないので、`removed` ブロック (`destroy = false`) で state から
+  外し、ファイルはノード上で `rm` する。**ストレージを移す変更は「置き換え」に
+  なるため、移動前のファイルが消せるかを先に確かめること。**
 - **Terraform が新規作成するゲストを HA に載せる場合、`ha.tf` の
   `proxmox_replication` に `depends_on` を足す。** 依存が無いとゲスト作成と
   並行してレプリケーションジョブ作成が走り「そんなゲストは無い」で失敗する。


### PR DESCRIPTION
## 概要

#86 のマージ後、apply が今度は**旧 cloud image の削除**で失敗した。

```
Error: Error deleting datastore file
Could not delete datastore file 'local:iso/debian-12-genericcloud-amd64.img',
unexpected error: error deleting file local:iso/debian-12-genericcloud-amd64.img
from datastore local: received an HTTP 400 response - Reason: Bad Request
```

`local` → `image-import` への移動は Terraform 上「置き換え」になるが、その destroy が PVE 側で拒否される。PVE は content_type ごとにファイル名と拡張子を検証しており、**`iso` 配下の `.img` は削除 API でも弾かれる**(#86 で作成時の検証に引っかかったのと同じ仕組み)。

**API 経由では消せないため、Terraform には忘れさせるしかない。**

## 変更内容

- **`removed` ブロック (`destroy = false`)** で旧リソースを state から外す
- 同じアドレスのままでは「置き換え = destroy が走る」ため、リソース名を `debian12_genericcloud` → **`debian12_import`** へ変更
- `import_from` の参照を新しい名前へ追従
- 同種の罠を次に踏まないための注意を [terraform/homelab/README.md](terraform/homelab/README.md) に記録

## ⚠️ apply とは別に人間の作業が必要

Terraform はもうこのファイルに触らないため、**残ったファイルは pve3 上で手動削除**してください(約 350MB)。

```bash
ssh root@192.168.1.11 'ls -la /var/lib/vz/template/iso/'
```

```bash
ssh root@192.168.1.11 'rm -i /var/lib/vz/template/iso/debian-12-genericcloud-amd64.img'
```

ファイルが既に存在しない可能性もあります(その場合 400 の原因は「存在しないファイルの削除」側で、bpg プロバイダの既知の挙動)。**どちらであっても `removed` ブロックにより apply は進みます。**

apply 後、state から外れたことを確認したら `removed` ブロックは削除して構いません。

## 確認事項

- `terraform fmt` / `validate` / `tflint` 通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)