### PR TITLE
feat(hcpterraform): minecraft-server-oci ワークスペースを取り込む

### DIFF
--- a/terraform/hcpterraform/README.md
+++ b/terraform/hcpterraform/README.md
@@ -1,7 +1,11 @@
 # HCP Terraform - ワークスペース管理
 
-HCP Terraform 自体を Terraform で管理するルート。本リポジトリが使う
-ワークスペースの設定をコード化する。
+HCP Terraform 自体を Terraform で管理するルート。`morihaya` org の
+ワークスペース設定をコード化する。
+
+管理対象は本リポジトリのワークスペースに限らない。org 内のワークスペースは
+このルートへ集約する。VCS のバックエンドとなるリポジトリはワークスペースごとに
+異なるため、[workspaces.tf](workspaces.tf) の `vcs_identifier` で個別に指定する。
 
 ## なぜやるのか
 
@@ -32,12 +36,24 @@ UI 任せの運用が実害を出している。
 | `-newrelic` | Default | `/terraform/newrelic/` | remote | **1.0.8** | false | **false** |
 | `-pagerduty` | Default | (なし) | **local** | **1.0.8** | false | false |
 | `-tailscale` | Default | (なし) | **local** | **1.0.8** | false | false |
+| `minecraft-server-oci` | OCI | `terraform` | remote | **1.12.2** | **true** | true |
 
 `-pagerduty` と `-tailscale` は VCS 連携が無く `execution_mode = local`。
 HCP は state の保管場所としてのみ使われ、plan / apply は手元で走る。
 
 `terraform/spotify` は HCP を使わずローカル state なので、対応する
 ワークスペースは存在しない。
+
+### 本リポジトリ外のワークスペース
+
+`minecraft-server-oci` だけは VCS のバックエンドが
+[morihaya/hayashi-ke-minecraft-server](https://github.com/morihaya/hayashi-ke-minecraft-server)
+で、OCI 上の Minecraft / BeamMP サーバのセキュリティリストを管理している。
+2026-07-31 に取り込んだ。
+
+`auto_apply` が有効なのでマージすれば適用まで自動で進む。その代わり apply が
+失敗しても PR 上には何も出ないため、リポジトリ側に `hcp-tf-comment.yml` を
+置いて run へのリンクをコメントさせている。
 
 > [!IMPORTANT]
 > 現時点のコードは**実態をそのまま写し取っているだけ**で、上表のバラつきは
@@ -121,9 +137,13 @@ terraform init
 terraform plan
 ```
 
-既存ワークスペースの取り込みは 2026-07-26 に完了済み
+本リポジトリのワークスペースの取り込みは 2026-07-26 に完了済み
 (`Plan: 7 to import, 0 to add, 0 to change, 0 to destroy.`)。
-取り込み用の `imports.tf` は役目を終えたので削除した。
+
+`minecraft-server-oci` は 2026-07-31 に取り込んだ
+(`Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.`)。
+取り込み用の [imports.tf](imports.tf) は apply 後に役目を終えるので削除すること
+(前回の取り込み時も同様に削除している)。
 
 ## 今後
 

--- a/terraform/hcpterraform/imports.tf
+++ b/terraform/hcpterraform/imports.tf
@@ -1,0 +1,13 @@
+# =============================================================================
+# 既存ワークスペースの取り込み
+#
+# tfe_workspace の import ID は "<ORGANIZATION>/<WORKSPACE NAME>"。
+#
+# apply が完了したらこのファイルは役目を終えるので削除すること
+# (前回の取り込み時も同様に imports.tf を削除している)。
+# =============================================================================
+
+import {
+  to = tfe_workspace.this["minecraft-server-oci"]
+  id = "morihaya/minecraft-server-oci"
+}

--- a/terraform/hcpterraform/variables.tf
+++ b/terraform/hcpterraform/variables.tf
@@ -10,8 +10,11 @@ variable "tfe_organization" {
   default     = "morihaya"
 }
 
+# このルートは org 内の他リポジトリのワークスペースも管理するため、
+# VCS のバックエンドは workspaces.tf の vcs_identifier で個別に指定する。
+# ここにあるのは本リポジトリのワークスペースが使う値。
 variable "vcs_repo_identifier" {
-  description = "GitHub repository backing the VCS-driven workspaces"
+  description = "GitHub repository backing the VCS-driven workspaces of this repository"
   type        = string
   default     = "morihaya/morihaya-infra"
 }

--- a/terraform/hcpterraform/workspaces.tf
+++ b/terraform/hcpterraform/workspaces.tf
@@ -1,8 +1,12 @@
 # =============================================================================
-# HCP Terraform workspaces used by this repository
+# HCP Terraform workspaces in the morihaya organization
 #
 # ここは「HCP Terraform 自体を管理する」ルート。UI でしか見えない設定が
 # 長期間放置されて実害が出たため IaC 化した (詳細は README.md)。
+#
+# 管理対象は本リポジトリのワークスペースに限らない。org 内のワークスペースは
+# ここへ集約する。VCS のバックエンドとなるリポジトリはワークスペースごとに
+# 異なるため vcs_identifier で個別に指定する。
 #
 # 【重要】この時点では実態をそのまま写し取ることだけを目的としている。
 # 下表のとおり terraform_version / auto_apply / speculative / working_directory
@@ -37,6 +41,11 @@ data "tfe_project" "homelab" {
   organization = var.tfe_organization
 }
 
+data "tfe_project" "oci" {
+  name         = "OCI"
+  organization = var.tfe_organization
+}
+
 data "tfe_project" "default" {
   name         = "Default Project"
   organization = var.tfe_organization
@@ -58,6 +67,7 @@ locals {
       auto_apply_run_trigger = true
       speculative_enabled    = true
       vcs                    = true
+      vcs_identifier         = var.vcs_repo_identifier
     }
 
     aws-root = {
@@ -75,6 +85,7 @@ locals {
       # speculative 無効。PR 時に plan が走らない。
       speculative_enabled = false
       vcs                 = true
+      vcs_identifier      = var.vcs_repo_identifier
     }
 
     azure = {
@@ -89,6 +100,7 @@ locals {
       auto_apply_run_trigger = true
       speculative_enabled    = true
       vcs                    = true
+      vcs_identifier         = var.vcs_repo_identifier
     }
 
     homelab = {
@@ -105,6 +117,7 @@ locals {
       auto_apply_run_trigger = false
       speculative_enabled    = true
       vcs                    = true
+      vcs_identifier         = var.vcs_repo_identifier
     }
 
     newrelic = {
@@ -120,6 +133,7 @@ locals {
       auto_apply_run_trigger = false
       speculative_enabled    = false
       vcs                    = true
+      vcs_identifier         = var.vcs_repo_identifier
     }
 
     # 2026-07-26 に local から remote へ移行した。以前は HCP を state の保管場所
@@ -138,6 +152,7 @@ locals {
       auto_apply_run_trigger = false
       speculative_enabled    = true
       vcs                    = true
+      vcs_identifier         = var.vcs_repo_identifier
     }
 
     tailscale = {
@@ -152,6 +167,32 @@ locals {
       auto_apply_run_trigger = false
       speculative_enabled    = false
       vcs                    = false
+      # VCS 連携が無いので参照されない。map の型を揃えるためだけに置いている。
+      vcs_identifier = null
+    }
+
+    # 本リポジトリ外のワークスペース。OCI 上の Minecraft サーバの
+    # セキュリティリストを管理する morihaya/hayashi-ke-minecraft-server が
+    # バックエンド。2026-07-31 に取り込んだ。
+    #
+    # auto_apply が有効なのでマージすれば適用まで自動で進む。その代わり
+    # apply が失敗しても PR 上に何も出ないため、リポジトリ側に
+    # hcp-tf-comment.yml を置いて run へのリンクをコメントさせている。
+    minecraft-server-oci = {
+      name              = "minecraft-server-oci"
+      description       = "GitHub Repo: https://github.com/morihaya/hayashi-ke-minecraft-server\n"
+      project_id        = data.tfe_project.oci.id
+      working_directory = "terraform"
+      # trigger_patterns が空の場合、HCP は working_directory を
+      # トリガとして扱う。実態どおり空のままにしている。
+      trigger_patterns       = []
+      terraform_version      = "1.12.2"
+      execution_mode         = "remote"
+      auto_apply             = true
+      auto_apply_run_trigger = true
+      speculative_enabled    = true
+      vcs                    = true
+      vcs_identifier         = "morihaya/hayashi-ke-minecraft-server"
     }
   }
 }
@@ -184,7 +225,7 @@ resource "tfe_workspace" "this" {
   dynamic "vcs_repo" {
     for_each = each.value.vcs ? [1] : []
     content {
-      identifier                 = var.vcs_repo_identifier
+      identifier                 = each.value.vcs_identifier
       github_app_installation_id = data.tfe_github_app_installation.this.id
       ingress_submodules         = false
     }


### PR DESCRIPTION
## 概要

`morihaya` org のワークスペースをこのルートへ集約していきます。手始めに、これまで UI 任せだった `minecraft-server-oci` を取り込みます。

このワークスペースは [morihaya/hayashi-ke-minecraft-server](https://github.com/morihaya/hayashi-ke-minecraft-server) をバックエンドに、OCI 上の Minecraft / BeamMP サーバのセキュリティリストを管理しています。**auto-apply が有効**でマージすれば適用まで自動で進む構成なので、設定が壊れたときの影響が大きい割に UI にしか実態がありませんでした。

## plan 結果

```
Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
```

実態をそのまま写し取っており、no-op であることを確認済みです。

## 取り込み時点の実態

| 項目 | 値 |
|---|---|
| project | OCI |
| working_directory | `terraform` |
| execution_mode | remote |
| terraform_version | **1.12.2** |
| auto_apply / auto_apply_run_trigger | **true / true** |
| speculative_enabled | true |
| trigger_patterns | `[]`（空の場合 HCP は working_directory をトリガとして扱う） |
| VCS | `morihaya/hayashi-ke-minecraft-server`（GitHub App `morihaya`） |

## 構造上の変更

`vcs_repo` の `identifier` が `var.vcs_repo_identifier` 固定でしたが、このワークスペースだけバックエンドのリポジトリが本リポジトリと異なるため、**ワークスペースごとの `vcs_identifier` に変更**しました。

`local.workspaces` は map なので全エントリで型を揃える必要があり、既存 7 件にも同じキーを追加しています。値は従来どおり `var.vcs_repo_identifier` なので挙動は変わりません。VCS 連携が無い `tailscale` のみ `null` です。

差分が膨らみますが、org 内の別リポジトリのワークスペースを扱う以上は避けられない変更です。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `workspaces.tf` | `minecraft-server-oci` エントリと `data "tfe_project" "oci"` を追加、`vcs_identifier` 化 |
| `imports.tf` | 新規。apply 後に削除する旨をコメントに記載 |
| `variables.tf` | `vcs_repo_identifier` の位置づけをコメントで明記 |
| `README.md` | 管理対象表に追記、「本リポジトリ外のワークスペース」節を追加 |

## 確認したこと

- `terraform fmt -check -recursive` → OK
- `terraform validate` → Success
- `tflint --recursive` → exit 0
- `terraform plan` → `1 to import, 0 to add, 0 to change, 0 to destroy`

## マージ後にやること

- [ ] apply 完了後、役目を終えた `imports.tf` を削除する

## レビューで見てほしい点

- plan 出力に `effective_tags = { "cloud" = "oci" }` が出ますが、これは OCI プロジェクトからの継承で `tag_names` / `tags` は空のため、コード側の指定は不要と判断しました（0 to change）
- `terraform_version` が `1.12.2` と他 (`~>1.14.0`) と揃っていませんが、README の方針どおり実態のまま記述しています。統一は既存 TODO に含まれる話として別 PR で

## 補足

README の `-pagerduty` の行が `local` / `1.0.8` のままで、コード側（`remote` / `~>1.14.0`）と食い違っています。2026-07-26 の変更時の更新漏れと思われますが、本 PR のスコープ外なので触っていません。

## 関連

`minecraft-server-oci` の run へのリンクを PR にコメントするワークフローを、リポジトリ側に別途追加しています → morihaya/hayashi-ke-minecraft-server#9

🤖 Generated with [Claude Code](https://claude.com/claude-code)