### PR TITLE
fix(homelab): VM 106 に cloud image 必須のシリアルコンソールを足す

### DIFF
--- a/docs/openclaw-butler-handover.md
+++ b/docs/openclaw-butler-handover.md
@@ -3,16 +3,37 @@
 - 作成: 2026-07-29(Claude Fable 5 セッションからの引き継ぎ用)
 - 更新: 2026-07-30(Phase 1 マージ済み、Phase 2 の VM コード化まで完了)
 - 目的: Proxmox 環境に OpenClaw を導入し、家族用 Slack に常駐する執事型 AI エージェントを構築する
-- 状態: **AWS 側は #84 でマージ済み。Proxmox VM 側 (Phase 2) は別 PR で実装中**
+- 状態: **AWS (#84) と VM (#85-#87) は apply 済み。VM がシリアルコンソール未定義で起動できず修正中**
 
 ## 0. 現在の進捗
 
 | Phase | 状態 | 補足 |
 |---|---|---|
-| 1. AWS 土台 | **コードは #84 でマージ済み** | plan は `3 added`。auto-apply 無効なので main の run を HCP UI で Confirm & Apply する |
-| 2. VM 構築 | **コード実装済み・apply 前** | `terraform/homelab/106vm_openclaw.tf`、HA 登録込み |
-| 3. OpenClaw セットアップ | 未着手 | VM 起動後 |
+| 1. AWS 土台 | **#84 マージ・apply 済み** | IAM ユーザ `openclaw-butler` と予算が存在するはず。アクセスキー発行と Model access 有効化は未確認 |
+| 2. VM 構築 | **apply 済みだが VM が起動しない** | #85 → #86 → #87 と修正を重ねて apply は通った。ただし起動時にカーネルパニック(下記)。シリアルコンソール追加で修正中 |
+| 3. OpenClaw セットアップ | 未着手 | VM が SSH 可能になってから |
 | 4. 執事化・運用 | 未着手 | |
+
+> [!CAUTION]
+> **VM 106 は起動に失敗している(2026-07-31 診断)。**
+>
+> apply 自体は成功し `qm status 106` は `running` だが、ゲストがネットワークへ
+> **1 パケットも出さない**(`ip -s link show tap106i0` の RX が 0)。
+> コンソールを screendump したところ次のパニックで停止していた。
+>
+> ```
+> Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
+> ```
+>
+> 原因は **シリアルコンソール未定義**。Debian の cloud image は
+> `console=tty0 console=ttyS0,115200 ...` をカーネルに渡しており、最後の
+> `console=` が `/dev/console` になる。Proxmox の VM は既定でシリアルポートを
+> 持たないため、PID 1 の書き込みが失敗して systemd が即死していた
+> (パニック直前のスタックが `ksys_write` なのと一致)。
+>
+> `serial_device { device = "socket" }` を足して修正。
+> cloud-init はこの起動失敗により**一度も走っていない**ので、
+> 修正後の初回起動でネットワーク設定と SSH 鍵が投入される。
 
 > [!NOTE]
 > Phase 1 と Phase 2 は当初 1 つの PR にまとめていたが、#84 が AWS 分だけの

--- a/terraform/homelab/106vm_openclaw.tf
+++ b/terraform/homelab/106vm_openclaw.tf
@@ -159,6 +159,26 @@ resource "proxmox_virtual_environment_vm" "vm_106" {
     firewall = true
   }
 
+  # シリアルコンソール。Debian の cloud image には必須。
+  #
+  # 【無いとどうなるか】
+  # イメージの GRUB 設定は次のようになっており、最後の console= が
+  # /dev/console になるため ttyS0 が存在しないと PID 1 の書き込みが失敗する。
+  #
+  #   GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0"
+  #
+  # 実際にこれを省いた初回起動は、カーネルは上がるものの systemd が即死して
+  # 次のパニックで止まった (ネットワークも 1 パケットも出ないまま)。
+  #
+  #   Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
+  #
+  # Proxmox の VM は既定でシリアルポートを持たないため、cloud image を使う
+  # ゲストでは明示的に足す必要がある。VGA はそのまま残すので Web コンソールも
+  # 従来どおり使える。
+  serial_device {
+    device = "socket"
+  }
+
   bios          = "seabios"
   scsi_hardware = "virtio-scsi-single"
   machine       = "pc"

--- a/terraform/homelab/README.md
+++ b/terraform/homelab/README.md
@@ -105,6 +105,15 @@ homelab/
   `import` タイプで置いている。`local` に `import` を足す手もあるが、`local` は
   全ノードの ISO・バックアップ・コンテナテンプレートを抱えているため
   Terraform 管理下に取り込まない。
+- **cloud image のゲストには `serial_device` が必須。** Debian の cloud image は
+  `console=tty0 console=ttyS0,115200` をカーネルに渡しており、最後の `console=`
+  が `/dev/console` になる。Proxmox の VM は既定でシリアルポートを持たないため、
+  足し忘れると PID 1 の書き込みが失敗して次のパニックで停止する。
+  ```
+  Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
+  ```
+  カーネルは起動しているのに**ネットワークへ 1 パケットも出ない**のが特徴。
+  `ip -s link show tap<vmid>i0` の RX が 0 なら、この症状を疑う。
 - **`iso` 配下に置いた `.img` は削除 API でも弾かれる。** PVE は content_type
   ごとにファイル名と拡張子を検証するため、`local:iso/*.img` を Terraform に
   destroy させると次のエラーで apply が止まる。


### PR DESCRIPTION
## 概要

#87 で apply は成功したが、**VM 106 が起動していなかった**。診断の結果、シリアルコンソール未定義が原因と判明したため修正する。

## 症状と診断

`qm status 106` は `running` だが、`192.168.1.12` に一切応答が無い。

```
$ ip -s link show tap106i0
RX:  bytes packets ...
         0       0          ← ゲストからの送信が 0
TX:  bytes packets errors dropped
        60       1      0  163496   ← ゲスト宛は全ドロップ
```

**カーネルは起動しているのにネットワークへ 1 パケットも出ていない。** ファイアウォールは無効 (`cluster.fw` / `106.fw` とも無し) なので経路の問題ではない。

コンソールを screendump したところ、次のパニックで停止していた。

```
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
```

パニック直前のスタックが `ksys_write` → `vfs_write` で、**PID 1 が書き込み中に死んでいる**。

cloud image を read-only でマウントして GRUB 設定を確認したところ、原因が確定した。

```
GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0"
```

**最後の `console=` が `/dev/console` になる**ため ttyS0 が必要。Proxmox の VM は既定でシリアルポートを持たないため、存在しないコンソールへの書き込みで systemd が即死していた。

## 変更内容

- `serial_device { device = "socket" }` を追加。VGA はそのまま残すので Web コンソールも従来どおり使える
- 症状と原因を [terraform/homelab/README.md](terraform/homelab/README.md) の約束ごとと [引き継ぎ計画書](docs/openclaw-butler-handover.md) に記録

## 補足

cloud-init はこの起動失敗により**一度も走っていない**ため、修正後の初回起動でネットワーク設定と SSH 鍵が投入される。ゲスト側に失われる状態は無い。

## 確認事項

- `terraform fmt` / `validate` / `tflint` 通過済み
- シリアルデバイスの追加はホットプラグできないため、apply 時に VM の停止・起動が発生する見込み(パニック中のため実害なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)