### PR TITLE
fix(homelab): VM 106 の DNS を明示し QEMU guest agent を有効化する

### DIFF
--- a/terraform/homelab/106vm_openclaw.tf
+++ b/terraform/homelab/106vm_openclaw.tf
@@ -142,6 +142,18 @@ resource "proxmox_virtual_environment_vm" "vm_106" {
       }
     }
 
+    # DNS は必ず明示する。
+    #
+    # 【省略するとどうなるか】
+    # PVE は nameserver 未指定のとき **ホスト (pve3) の /etc/resolv.conf を
+    # ゲストの cloud-init 設定に引き継ぐ**。pve3 は Tailscale の MagicDNS
+    # (100.100.100.100) を向いているため、Tailscale が入っていないこの VM は
+    # 名前解決が一切できなくなる。実際に初回起動では cloud-init の
+    # `apt-get update` がハングしたまま数分間止まっていた。
+    dns {
+      servers = ["192.168.1.4"] # AdGuard Home (LXC 100)
+    }
+
     user_account {
       username = "morihaya"
       # ansible 側と鍵の実体を二重管理しないよう、common ロールの
@@ -188,9 +200,13 @@ resource "proxmox_virtual_environment_vm" "vm_106" {
     type = "l26"
   }
 
-  # QEMU Guest Agent は Debian の genericcloud イメージに同梱されていないため
-  # 有効化しない (有効にすると provider が起動時にエージェント応答を待ち続ける)。
-  # 導入後に ansible で qemu-guest-agent を入れてから有効化する。
+  # QEMU Guest Agent。genericcloud イメージには同梱されていないため、
+  # ゲスト側へ qemu-guest-agent を導入してから有効化した (2026-07-31)。
+  # ゲストに入れずにこれを有効化すると、provider が起動時にエージェントの
+  # 応答を待ち続けるので順序を逆にしないこと。
+  agent {
+    enabled = true
+  }
 
   startup {
     down_delay = -1


### PR DESCRIPTION
## 概要

#89 で VM 106 は起動したが、Phase 3 の作業中に**名前解決ができない**ことが判明したため修正する。併せて guest agent を有効化する。

## DNS

`initialization` に `dns` を書いていなかったため、**PVE がホスト (pve3) の `/etc/resolv.conf` をゲストの cloud-init 設定へ引き継いでいた**。

```
$ cat /etc/resolv.conf   # VM 106
nameserver 100.100.100.100        ← Tailscale MagicDNS
nameserver fd7a:115c:a1e0::53
search tailc3c3c.ts.net
```

pve3 は Tailscale の MagicDNS を向いているが、**VM 106 に Tailscale は入っていない**ため名前解決が一切できない。初回起動の cloud-init はこれが原因で `apt-get update` のまま数分間ハングしていた(`cloud-final.service` が `activating` のまま)。

AdGuard Home (LXC 100 / 192.168.1.4) を明示する。疎通は確認済み。

```
$ host deb.debian.org 192.168.1.4
debian.map.fastlydns.net has address 151.101.2.132
```

## QEMU guest agent

ゲストへ `qemu-guest-agent` を導入したので `agent { enabled = true }` にする。
**ゲストに入れる前に有効化すると provider が起動時にエージェント応答を待ち続ける**ため、順序を逆にしないようコメントを残した。

## 確認事項

- `terraform fmt` / `validate` / `tflint` 通過済み
- apply 後、cloud-init はブートごとにネットワーク設定を再適用するため、**VM の再起動で `/etc/resolv.conf` が 192.168.1.4 に切り替わる**
- 現在の VM には作業継続のため `resolvectl` で暫定的に同じ DNS を設定済み。apply + 再起動で宣言どおりの状態に収束する

🤖 Generated with [Claude Code](https://claude.com/claude-code)