### PR TITLE
feat(openclaw): 執事エージェントのデプロイ資材を追加する

### DIFF
--- a/docker/openclaw/.env.example
+++ b/docker/openclaw/.env.example
@@ -1,0 +1,23 @@
+# OpenClaw の秘密情報。実体は VM 106 上の ~/openclaw/.env に置く。
+# このファイルは雛形なので、実際の値は絶対にコミットしないこと。
+# (.gitignore で .env は除外済み)
+
+# ---------------------------------------------------------------------------
+# AWS / Amazon Bedrock
+# ---------------------------------------------------------------------------
+# terraform/aws/root で作った IAM ユーザ openclaw-butler のアクセスキー。
+# 権限は Anthropic モデルの呼び出しとモデル一覧の取得のみに絞ってある。
+#
+#   aws iam create-access-key --user-name openclaw-butler
+#
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# ---------------------------------------------------------------------------
+# Slack (Socket Mode)
+# ---------------------------------------------------------------------------
+# Slack アプリの設定画面で発行する。手順は README.md を参照。
+#   App-Level Token (connections:write スコープ)
+SLACK_APP_TOKEN=
+#   Bot User OAuth Token
+SLACK_BOT_TOKEN=

--- a/docker/openclaw/README.md
+++ b/docker/openclaw/README.md
@@ -1,0 +1,135 @@
+# OpenClaw 執事エージェント
+
+自宅 Slack に常駐する執事型 AI エージェント。VM 106 (`192.168.1.12`) の Docker で動かす。
+設計の経緯と全体計画は [docs/openclaw-butler-handover.md](../../docs/openclaw-butler-handover.md) を参照。
+
+## 構成
+
+| 項目 | 値 |
+|------|-----|
+| ホスト | VM 106 `openclaw` / 192.168.1.12 (pve3, HA 対象) |
+| イメージ | `ghcr.io/openclaw/openclaw:latest` |
+| モデル | Amazon Bedrock (ap-northeast-1) / 既定 Claude Haiku 4.5 |
+| チャネル | Slack Socket Mode (inbound のポート公開なし) |
+| デプロイ先 | `~/openclaw/` |
+
+VM そのものは Terraform 管理 ([terraform/homelab/106vm_openclaw.tf](../../terraform/homelab/106vm_openclaw.tf))。
+
+## ディレクトリ構成
+
+```
+~/openclaw/                    # VM 106 上
+├── compose.yaml               # このリポジトリから配布
+├── .env                       # 秘密情報 (git 管理外・手で作る)
+└── data/
+    ├── config/                # /home/node/.openclaw
+    │   ├── openclaw.json      # このリポジトリから配布
+    │   └── workspace/         # メモリ・自宅情報
+    └── secrets/               # /home/node/.config/openclaw
+```
+
+## セットアップ
+
+### 1. 資材を配る
+
+```bash
+scp compose.yaml morihaya@192.168.1.12:~/openclaw/
+```
+
+```bash
+scp openclaw.json morihaya@192.168.1.12:~/openclaw/data/config/
+```
+
+### 2. 秘密情報を置く
+
+`.env.example` を雛形に、VM 上で `~/openclaw/.env` を作る。**この作業だけは手で行う**
+(アクセスキーやトークンをリポジトリにも会話にも残さないため)。
+
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+  IAM ユーザ `openclaw-butler` のもの。`aws iam create-access-key --user-name openclaw-butler`
+- `SLACK_APP_TOKEN` / `SLACK_BOT_TOKEN` — 次項で発行する
+
+```bash
+chmod 600 ~/openclaw/.env
+```
+
+### 3. Slack アプリを作る
+
+<https://api.slack.com/apps> で新規作成し、以下を設定する。
+
+1. **Socket Mode** を有効化 → App-Level Token (`xapp-`) を `connections:write` スコープで発行
+2. **OAuth & Permissions** で Bot Token Scopes を付与
+
+   ```
+   app_mentions:read, channels:history, channels:read, chat:write, commands,
+   files:read, files:write, groups:history, groups:read, im:history, im:read,
+   im:write, mpim:history, mpim:read, mpim:write, reactions:read,
+   reactions:write, users:read
+   ```
+
+3. **Event Subscriptions** で購読
+
+   ```
+   app_mention, message.channels, message.groups, message.im, message.mpim
+   (任意: app_home_opened, pin_added, reaction_added)
+   ```
+
+4. **App Home** で Messages Tab を有効化 (DM を使うため)
+5. ワークスペースにインストールし、Bot User OAuth Token (`xoxb-`) を取得
+
+### 4. 許可リストを埋める
+
+`openclaw.json` の `allowFrom` に家族の Slack ユーザー ID (`U...`)、
+常駐させるチャンネルがあれば `channels` にチャンネル ID (`C...`) を入れる。
+
+> [!IMPORTANT]
+> **表示名ではなく ID で書くこと。** 起動時に ID で解決されるため、
+> 名前で書くと黙って無視される。
+
+### 5. 起動
+
+```bash
+cd ~/openclaw && docker compose up -d
+```
+
+```bash
+docker compose logs -f
+```
+
+## 運用
+
+### モデル ID の確認
+
+`openclaw.json` の `model.primary` は `bedrockDiscovery` で見えている ID と
+一致している必要がある。
+
+```bash
+docker compose exec openclaw openclaw models list
+```
+
+### Control UI
+
+LAN へは晒していないので、手元から見る場合は SSH ポートフォワードする。
+
+```bash
+ssh -L 18789:127.0.0.1:18789 morihaya@192.168.1.12
+```
+
+その後ブラウザで <http://127.0.0.1:18789/>。
+
+### 更新
+
+```bash
+cd ~/openclaw && docker compose pull && docker compose up -d
+```
+
+## セキュリティ上の約束ごと
+
+- **OpenClaw は認証情報を平文で保存する。** IAM は Bedrock の呼び出しのみに
+  絞ってあり、AWS Budgets のアラートも設定済み。キーは定期的に回す
+- **Control UI を LAN へ公開しない。** 過去に公開インスタンスの大量露出が
+  問題になっている
+- **ClawHub のスキルは入れる前にソースを読む。** エージェントと同じ権限で
+  動くコードとして扱う
+- **プロンプトインジェクションに注意。** エージェントが読む外部コンテンツ経由で
+  指示が混入しうる。永続メモリを持つぶん汚染が残りやすい

--- a/docker/openclaw/compose.yaml
+++ b/docker/openclaw/compose.yaml
@@ -1,0 +1,38 @@
+# OpenClaw 執事エージェント (VM 106 / 192.168.1.12)
+#
+# 秘密情報は .env に置く (git 管理外)。.env.example を参照。
+services:
+  openclaw:
+    image: ghcr.io/openclaw/openclaw:latest
+    container_name: openclaw
+    restart: unless-stopped
+
+    # AWS のアクセスキーと Slack のトークンはここから読む
+    env_file: .env
+
+    environment:
+      # Bedrock は東京リージョン固定。モデルは openclaw.json 側で指定する。
+      AWS_REGION: ap-northeast-1
+
+    volumes:
+      # 設定・認証情報・会話履歴・workspace が全てこの下に載る。
+      # コンテナは uid 1000 (node) で動き、VM 側の morihaya も uid 1000 なので
+      # ホスト側のファイル所有者はそのままで良い。
+      - ./data/config:/home/node/.openclaw
+      # 認証プロファイルの秘密ディレクトリは別系統
+      - ./data/secrets:/home/node/.config/openclaw
+
+    ports:
+      # Control UI。LAN へは晒さず 127.0.0.1 に閉じる。
+      # 手元から見たい場合は SSH ポートフォワードを使う (README 参照)。
+      - "127.0.0.1:18789:18789"
+
+    # エージェントがシェルを実行できる以上、コンテナ側でも素直に絞っておく
+    security_opt:
+      - no-new-privileges:true
+
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -1,0 +1,58 @@
+// OpenClaw 執事エージェントの設定 (JSON5: コメント・末尾カンマが使える)
+//
+// 配置先: VM 106 の ~/openclaw/data/config/openclaw.json
+//         (コンテナ内では /home/node/.openclaw/openclaw.json)
+//
+// 秘密情報はここに書かない。トークン類は .env から環境変数で渡す。
+{
+  agents: {
+    defaults: {
+      // 普段使いは Haiku。重い依頼だけ Slack で `/model` を使って
+      // Sonnet に切り替える運用にする (コストは docs の想定で月千円台)。
+      //
+      // NOTE: モデル ID は bedrockDiscovery の結果に合わせて確定させること。
+      // `docker compose exec openclaw openclaw models list` で実際に
+      // 見えている ID を確認する。apac.* はクロスリージョン推論プロファイル。
+      model: {
+        primary: 'amazon-bedrock/apac.anthropic.claude-haiku-4-5-20251001-v1:0',
+      },
+    },
+  },
+
+  models: {
+    // 利用可能な Bedrock モデルを API から自動発見する。
+    // IAM 側で ListFoundationModels / ListInferenceProfiles を許可済み。
+    bedrockDiscovery: {
+      enabled: true,
+      region: 'ap-northeast-1',
+    },
+  },
+
+  channels: {
+    slack: {
+      enabled: true,
+
+      // Socket Mode。自宅側にポート公開も固定 IP も要らない。
+      mode: 'socket',
+      appToken: { source: 'env', provider: 'default', id: 'SLACK_APP_TOKEN' },
+      botToken: { source: 'env', provider: 'default', id: 'SLACK_BOT_TOKEN' },
+
+      // DM は家族のみに限定する。
+      //
+      // TODO: 家族の Slack ユーザー ID (U で始まる) を入れる。
+      // 空のままだと誰とも DM できないので、起動前に必ず埋めること。
+      // ID は Slack のプロフィール > その他 > メンバー ID からコピーできる。
+      // 表示名では動かない (起動時に ID で解決されるため)。
+      dmPolicy: 'allowlist',
+      allowFrom: [],
+
+      // チャンネルも許可制。メンションされた時だけ反応する。
+      //
+      // TODO: 常駐させたいチャンネル ID (C で始まる) を入れる。
+      groupPolicy: 'allowlist',
+      channels: {
+        // 'C0123456789': { requireMention: true },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 概要

Phase 3。VM 106 で動かす OpenClaw の compose とアプリ設定をリポジトリで管理する。
VM 側 (`~/openclaw/`) には配布済みで、**あとは秘密情報と許可リストを埋めれば起動できる**状態。

## 追加するもの

| ファイル | 内容 |
|---|---|
| `compose.yaml` | `ghcr.io/openclaw/openclaw:latest` を `restart: unless-stopped` で常駐 |
| `openclaw.json` | Bedrock の Haiku を既定に、Slack は Socket Mode。DM・チャンネルとも allowlist |
| `.env.example` | 秘密情報の雛形。実体の `.env` は git 管理外 |
| `README.md` | Slack アプリのスコープ・イベント購読、モデル ID 確認、運用の約束ごと |

## 設計上の判断

- **Control UI は LAN へ晒さない。** `127.0.0.1:18789` に閉じ、手元から見る場合は SSH ポートフォワード。公開インスタンスの露出が過去に問題化しているため
- **DM もチャンネルも allowlist。** `dmPolicy` / `groupPolicy` を `allowlist` にして家族以外は弾く。**Slack の ID (`U...` / `C...`) で書く必要がある**(表示名は起動時の解決で黙って無視される)
- **秘密情報はリポジトリにも会話にも残さない。** `.env` は VM 上で手で埋める運用
- `no-new-privileges` とログローテーションを付けた。エージェントがシェルを実行できる以上、コンテナ側でも素直に絞っておく

## VM 側の状態 (完了済み)

- Docker 29.7.0 / Compose v5.3.1 導入
- `qemu-guest-agent` 導入(Terraform 側の有効化は #90)
- イメージ取得済み (OpenClaw 2026.6.34)
- `compose.yaml` / `openclaw.json` 配布済み、`docker compose config` 通過

## 起動前に必要な手作業

1. `~/openclaw/.env` に IAM ユーザ `openclaw-butler` のアクセスキーを記入
2. Slack アプリを作成し、`SLACK_APP_TOKEN` / `SLACK_BOT_TOKEN` を記入(手順は README)
3. `openclaw.json` の `allowFrom` に家族の Slack ユーザー ID を記入

🤖 Generated with [Claude Code](https://claude.com/claude-code)