### PR TITLE
feat(openclaw): コンテナのタイムゾーンを JST にする

### DIFF
--- a/docker/openclaw/compose.yaml
+++ b/docker/openclaw/compose.yaml
@@ -14,6 +14,11 @@ services:
       # Bedrock は東京リージョン固定。モデルは openclaw.json 側で指定する。
       AWS_REGION: ap-northeast-1
 
+      # コンテナのタイムゾーン。ホスト (VM 106) の設定は引き継がれないため
+      # ここで明示する。定時通知や cron はコンテナ内の時刻で動くので、
+      # UTC のままだと朝のブリーフィングが 9 時間ずれる。
+      TZ: Asia/Tokyo
+
     volumes:
       # 設定・認証情報・会話履歴・workspace が全てこの下に載る。
       # コンテナは uid 1000 (node) で動き、VM 側の morihaya も uid 1000 なので


### PR DESCRIPTION
## 概要

VM 106 のタイムゾーンを `Asia/Tokyo` にした。**ホストの設定はコンテナに引き継がれない**ため、compose 側でも `TZ` を明示する。

定時通知や cron はコンテナ内の時刻で動くので、UTC のままだと朝のブリーフィングが 9 時間ずれる。

```
TZ 指定あり: Fri Jul 31 23:15:49 JST 2026
TZ 指定なし: Fri Jul 31 14:15:50 UTC 2026
```

## 変更内容

- `compose.yaml` の `environment` に `TZ: Asia/Tokyo` を追加

## VM 側 (適用済み・コード管理外)

```
$ timedatectl
Time zone: Asia/Tokyo (JST, +0900)
System clock synchronized: yes
```

既存の Proxmox 3 ノードも全て `Asia/Tokyo` なので、これでクラスタ内で揃った。

> [!NOTE]
> VM 側のタイムゾーンとロケール生成 (`en_US.UTF-8` / `ja_JP.UTF-8`) は
> **手作業のため VM を作り直すと消える**。ansible での恒久化は別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)