### PR TITLE
feat(ansible): 全管理ホストのタイムゾーンとロケールを揃える

### DIFF
--- a/ansible/inventories/group_vars/all.yml
+++ b/ansible/inventories/group_vars/all.yml
@@ -1,4 +1,24 @@
 ---
+# =============================================================================
+# システム基本設定
+#
+# 自宅は日本にあるので全ホストを JST に揃える。
+#
+# ロケールは cloud image 由来のホストで問題になった。Debian の genericcloud
+# には C.utf8 しか無く、macOS から SSH すると LC_ALL=en_US.UTF-8 が転送されて
+# 解決に失敗する。その結果 vim の encoding が latin1 に落ち、日本語が
+# 文字化けする (VM 106 で実際に発生)。
+#
+#   -bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+#
+# =============================================================================
+timezone: 'Asia/Tokyo'
+
+locales:
+  - 'en_US.UTF-8'
+  - 'ja_JP.UTF-8'
+
+
 users:
   - name: "morihaya"
     # "!!" はパスワードをロックする指定。ログインは SSH 公開鍵のみ。

--- a/ansible/inventories/hosts.yml
+++ b/ansible/inventories/hosts.yml
@@ -22,6 +22,7 @@ all:
       children:
         proxmox: {}
         containers: {}
+        vms: {}
 
     # ---- ハイパーバイザ (Debian 13 / PVE 9.1) ----
     proxmox:
@@ -42,6 +43,15 @@ all:
           ansible_host: 192.168.1.8 # ダッシュボード / Debian 12
         gh-runner:
           ansible_host: 192.168.1.9 # GitHub Actions ランナー (未セットアップ) / Debian 12
+
+    # ---- VM ----
+    vms:
+      hosts:
+        openclaw:
+          ansible_host: 192.168.1.12 # OpenClaw 執事エージェント / Debian 12 (cloud image)
+          # cloud image は root の SSH 鍵を持たない。cloud-init が作った
+          # morihaya (sudo NOPASSWD) で入り、become で昇格する。
+          ansible_user: morihaya
 
     # =========================================================================
     # まだ管理下に置けないホスト。

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,3 +1,5 @@
 ---
 collections:
   - name: ansible.posix
+  # timezone / locale_gen モジュールを使う
+  - name: community.general

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,4 +1,29 @@
 ---
+- name: Set timezone
+  community.general.timezone:
+    name: '{{ timezone }}'
+  tags:
+    - system
+    - timezone
+
+# cloud image には locales が入っていないことがある
+- name: Install locales package
+  ansible.builtin.package:
+    name: locales
+    state: present
+  tags:
+    - system
+    - locale
+
+- name: Generate locales
+  community.general.locale_gen:
+    name: '{{ item }}'
+    state: present
+  loop: '{{ locales }}'
+  tags:
+    - system
+    - locale
+
 - name: Add users
   ansible.builtin.user:
     name: '{{ item.name }}'


### PR DESCRIPTION
## 概要

自宅は日本にあるので、`common` ロールで全管理ホストを **JST + UTF-8 ロケール**に統一する。
VM 106 で手作業していた設定をコード化し、作り直しても失われないようにする。

## 変更内容

| ファイル | 内容 |
|---|---|
| `roles/common/tasks/main.yml` | `timezone` / `locales` パッケージ導入 / `locale_gen` の 3 タスク (タグ `system`) |
| `inventories/group_vars/all.yml` | `timezone: Asia/Tokyo`、`locales: [en_US.UTF-8, ja_JP.UTF-8]` |
| `inventories/hosts.yml` | `vms` グループを新設し VM 106 (openclaw) を追加 |
| `requirements.yml` | `community.general` を追加 (timezone / locale_gen モジュール用) |

### ロケールを揃える理由

Debian の cloud image には `C.utf8` しか無い。macOS から SSH すると
`LC_ALL=en_US.UTF-8` が転送されるが、解決に失敗して警告が出る。

```
-bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```

結果として **vim の `encoding` が `latin1` に落ち、日本語が文字化けする**。VM 106 で実際に発生した。

### openclaw だけ ansible_user が違う

cloud image は root の SSH 鍵を持たないため、cloud-init が作った `morihaya` (sudo NOPASSWD) で入って `become` で昇格する。

## 適用結果

**適用済み。** dry-run で `dns01` と `gh-runner` が `Etc/UTC` のままだったことが判明した。

```
dns01      : changed=2   (timezone + locale)
gh-runner  : changed=2   (timezone + locale)
homepage   : changed=1   (ja_JP.UTF-8)
pve        : changed=1   (ja_JP.UTF-8)
pve2       : changed=1   (ja_JP.UTF-8)
pve3       : changed=1   (ja_JP.UTF-8)
openclaw   : changed=0   (手作業の状態と一致)
```

適用後、全 7 ホストで確認済み。

```
homepage | TZ=Asia/Tokyo locales=2
pve      | TZ=Asia/Tokyo locales=2
dns01    | TZ=Asia/Tokyo locales=2
pve3     | TZ=Asia/Tokyo locales=2
gh-runner| TZ=Asia/Tokyo locales=2
openclaw | TZ=Asia/Tokyo locales=2
pve2     | TZ=Asia/Tokyo locales=2
```

> [!NOTE]
> 実行は `--tags system` に限定した。`common` ロールの既存タスク
> (users / authorized_keys / bashrc) は動かしていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)