### PR TITLE
feat(openclaw): 実機で動かして判明した設定を反映する

### DIFF
--- a/docker/openclaw/.env.example
+++ b/docker/openclaw/.env.example
@@ -21,3 +21,14 @@ AWS_SECRET_ACCESS_KEY=
 SLACK_APP_TOKEN=
 #   Bot User OAuth Token
 SLACK_BOT_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Control UI
+# ---------------------------------------------------------------------------
+# 未設定だと gateway が "Refusing to bind gateway to auto without auth" で
+# 起動しない。コンテナ内では 0.0.0.0 に bind されるため (compose 側で
+# 127.0.0.1 に閉じてはいる)。生成は次のとおり。
+#
+#   printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$(openssl rand -hex 32)" >> .env
+#
+OPENCLAW_GATEWAY_TOKEN=

--- a/docker/openclaw/README.md
+++ b/docker/openclaw/README.md
@@ -40,6 +40,49 @@ scp compose.yaml morihaya@192.168.1.12:~/openclaw/
 scp openclaw.json morihaya@192.168.1.12:~/openclaw/data/config/
 ```
 
+### 0. Bedrock の use case details を提出する
+
+**Anthropic モデルはモデルアクセスの有効化だけでは呼べない。** アカウント単位で
+use case details の提出が要る。未提出だとモデルを問わず次で失敗する。
+
+```
+ResourceNotFoundException: Model use case details have not been submitted for
+this account. Fill out the Anthropic use case details form before using the
+model. If you have already filled out the form, try again in 15 minutes.
+```
+
+Bedrock コンソール (ap-northeast-1) の Model access からフォームを提出する。
+反映まで数分かかる。
+
+> [!TIP]
+> OpenClaw を疑う前に AWS CLI で切り分けられる。これが通らなければ AWS 側の問題。
+>
+> ```bash
+> aws bedrock-runtime converse --region ap-northeast-1 --model-id jp.anthropic.claude-haiku-4-5-20251001-v1:0 --messages '[{"role":"user","content":[{"text":"hi"}]}]'
+> ```
+
+### 1.5. プラグインを入れる
+
+**Bedrock も Slack も標準イメージに同梱されていない** (同梱チャネルは telegram のみ)。
+入れないと、起動はするが Bedrock は `No API provider registered for api:
+bedrock-converse-stream`、Slack は無反応になる。
+
+```bash
+docker compose exec openclaw openclaw plugins install @openclaw/amazon-bedrock-provider
+```
+
+```bash
+docker compose exec openclaw openclaw plugins install @openclaw/slack
+```
+
+インストール先は `~/.openclaw/npm/` 配下 (バインドマウント下) なので永続する。
+
+> [!IMPORTANT]
+> インストーラは `openclaw.json` を書き換えようとするが、コメントごと消える
+> 縮小になるため OpenClaw 自身の安全機構に弾かれる (`Config write rejected:
+> size-drop`)。**これは想定どおり**で、`plugins.entries` と `plugins.allow` は
+> リポジトリ側の設定ファイルに既に書いてある。
+
 ### 2. 秘密情報を置く
 
 `.env.example` を雛形に、VM 上で `~/openclaw/.env` を作る。**この作業だけは手で行う**

--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -5,6 +5,13 @@
 //
 // 秘密情報はここに書かない。トークン類は .env から環境変数で渡す。
 {
+  // Gateway の動作モード。
+  // 未設定だと起動時に弾かれる (設定を書き換えられた可能性を疑う挙動):
+  //   Gateway start blocked: existing config is missing gateway.mode.
+  gateway: {
+    mode: 'local',
+  },
+
   agents: {
     defaults: {
       // 普段使いは Haiku。重い依頼だけ Slack で `/model` を使って
@@ -13,18 +20,101 @@
       // NOTE: モデル ID は bedrockDiscovery の結果に合わせて確定させること。
       // `docker compose exec openclaw openclaw models list` で実際に
       // 見えている ID を確認する。apac.* はクロスリージョン推論プロファイル。
+      // 普段使いは Haiku。重い依頼だけ Slack で `/model` を使って
+      // Sonnet に切り替える運用にする。
+      //
+      // 【2026-07-31 時点の未解決事項】
+      // Bedrock の Anthropic モデルはアカウント単位で use case details の
+      // 提出が要る。未提出だと Haiku / Sonnet の区別なく次で失敗する。
+      //
+      //   ResourceNotFoundException: Model use case details have not been
+      //   submitted for this account. Fill out the Anthropic use case
+      //   details form before using the model. If you have already filled
+      //   out the form, try again in 15 minutes.
+      //
+      // OpenClaw の問題ではない。AWS CLI から直接 Converse を叩いても同じ。
+      // Bedrock コンソールでフォームを提出すれば解消する。
+      //
+      // なお fallbacks に別モデルを置いても肩代わりしない。この例外は
+      // failover 対象の失敗として扱われないため、代替モデルの用意は無意味。
       model: {
-        primary: 'amazon-bedrock/apac.anthropic.claude-haiku-4-5-20251001-v1:0',
+        primary: 'amazon-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0',
+      },
+
+      // メモリの意味検索 (semantic recall) は既定で OpenAI の埋め込みを使う。
+      // このホストには OPENAI_API_KEY を置かない方針なので無効化する。
+      //
+      //   Memory search provider is set to "openai" but no API key was found.
+      //
+      // 無効でもワークスペース上のファイルによる記憶は従来どおり働く。
+      // Bedrock の埋め込みモデルへ向ける手もあるので、必要になったら見直す。
+      memorySearch: {
+        enabled: false,
+      },
+    },
+  },
+
+  plugins: {
+    // 同梱外のプラグインを明示的に信頼する。空にしておくと「見つかったものが
+    // 自動で読み込まれうる」状態になり、起動のたびに警告が出る。
+    // エージェントと同じ権限で動くコードなので、増やす際は素性を確認すること。
+    allow: ['amazon-bedrock', 'slack'],
+
+    entries: {
+      // Bedrock プロバイダは標準イメージに同梱されていない。
+      // 有効化しないと起動はするが実行時に次で失敗する。
+      //
+      //   No API provider registered for api: bedrock-converse-stream
+      //
+      // 導入は VM 上で一度だけ実行する (~/.openclaw/npm 配下に入るので永続する)。
+      //   docker compose exec openclaw \
+      //     openclaw plugins install @openclaw/amazon-bedrock-provider
+      'amazon-bedrock': {
+        enabled: true,
+      },
+
+      // Slack チャネルも同梱外。同梱されているのは telegram のみ。
+      // 入れないとチャネルが起動せず、Slack から一切反応しない。
+      //   docker compose exec openclaw openclaw plugins install @openclaw/slack
+      slack: {
+        enabled: true,
       },
     },
   },
 
   models: {
-    // 利用可能な Bedrock モデルを API から自動発見する。
-    // IAM 側で ListFoundationModels / ListInferenceProfiles を許可済み。
-    bedrockDiscovery: {
-      enabled: true,
-      region: 'ap-northeast-1',
+    providers: {
+      // Bedrock は組み込みプロバイダだが、使うモデルは明示的に宣言する必要が
+      // ある。宣言しないと起動はするものの、実行時に次で失敗する。
+      //
+      //   FailoverError: Unknown model: amazon-bedrock/...
+      //
+      // 利用可能な ID は次で確認できる (要 IAM 権限)。
+      //   aws bedrock list-inference-profiles --region ap-northeast-1
+      'amazon-bedrock': {
+        baseUrl: 'https://bedrock-runtime.ap-northeast-1.amazonaws.com',
+        api: 'bedrock-converse-stream',
+        // アクセスキーは .env から環境変数で渡す (AWS SDK の既定の解決順)
+        auth: 'aws-sdk',
+
+        // jp.* は日本国内で完結するクロスリージョン推論プロファイル。
+        // apac.* はシドニーやシンガポールへもルーティングされうるため、
+        // 自宅の情報を扱うこの用途では jp.* を選ぶ。
+        models: [
+          {
+            id: 'jp.anthropic.claude-haiku-4-5-20251001-v1:0',
+            name: 'Claude Haiku 4.5 (Bedrock JP)',
+            contextWindow: 200000,
+            maxTokens: 8192,
+          },
+          {
+            id: 'jp.anthropic.claude-sonnet-4-6',
+            name: 'Claude Sonnet 4.6 (Bedrock JP)',
+            contextWindow: 200000,
+            maxTokens: 8192,
+          },
+        ],
+      },
     },
   },
 


### PR DESCRIPTION
## 概要

VM 106 で実際に起動するまでに必要だった設定を全て取り込む。
**gateway は healthy で稼働中、Slack は socket mode で接続済み。**

```
openclaw  [gateway] agent model: amazon-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0
openclaw  [slack] socket mode connected
```

## 変更内容

| 項目 | 内容 |
|---|---|
| `gateway.mode` | 未設定だと `existing config is missing gateway.mode` で起動を拒否される |
| `plugins` | **Bedrock も Slack も標準イメージに同梱されていない**(同梱チャネルは telegram のみ)。外部プラグインの導入と有効化が必要。`plugins.allow` で読み込む範囲も明示的に絞った |
| `models.providers` | このバージョンに `models.bedrockDiscovery` は**存在しない**。モデルを明示宣言しないと実行時に `Unknown model` |
| モデル | **`jp.*` 推論プロファイル**に変更。`apac.*` はシドニー・シンガポールへルーティングされうるが `jp.*` は国内完結 |
| `memorySearch` | 既定で OpenAI の埋め込みを要求するため無効化 |
| `.env.example` | `OPENCLAW_GATEWAY_TOKEN` を追記。未設定だと `Refusing to bind gateway to auto without auth` |

### プラグインが同梱外だった件

導入コマンドは README に記載。インストール先は `~/.openclaw/npm/` (バインドマウント下) なので永続する。

インストーラは `openclaw.json` を書き換えようとするが、**コメントごと消える縮小になるため OpenClaw 自身の安全機構に弾かれる** (`Config write rejected: size-drop`)。これは想定どおりで、必要なキーはリポジトリ側の設定に手で書いてある。

## ⚠️ 残件: Bedrock の use case details 未提出

**Anthropic モデルはモデルアクセスの有効化だけでは呼べない。** アカウント単位で use case details の提出が要る。

```
ResourceNotFoundException: Model use case details have not been submitted for
this account. Fill out the Anthropic use case details form before using the
model. If you have already filled out the form, try again in 15 minutes.
```

**OpenClaw の問題ではない。** OpenClaw を介さず AWS CLI から直接 `bedrock-runtime converse` を叩いても同じエラーになることを確認済み。Haiku / Sonnet の区別なく発生する。

`fallbacks` に別モデルを置いても肩代わりしない(この例外は failover 対象の失敗として扱われない)ため、代替モデルの用意では回避できない。

Bedrock コンソール (ap-northeast-1) の Model access からフォームを提出すれば解消する見込み。

## 起動に残る手作業

1. 上記の use case details フォーム提出
2. `openclaw.json` の `allowFrom` に家族の Slack ユーザー ID (`U...`) を記入

🤖 Generated with [Claude Code](https://claude.com/claude-code)