### PR TITLE
feat(openclaw): Slack の DM 許可リストに家族のユーザ ID を設定する

### DIFF
--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -127,14 +127,14 @@
       appToken: { source: 'env', provider: 'default', id: 'SLACK_APP_TOKEN' },
       botToken: { source: 'env', provider: 'default', id: 'SLACK_BOT_TOKEN' },
 
-      // DM は家族のみに限定する。
-      //
-      // TODO: 家族の Slack ユーザー ID (U で始まる) を入れる。
-      // 空のままだと誰とも DM できないので、起動前に必ず埋めること。
-      // ID は Slack のプロフィール > その他 > メンバー ID からコピーできる。
+      // DM は家族のみに限定する。空にすると全 DM が破棄される。
+      // ID は Slack のプロフィール > その他 > メンバー ID からコピーする。
       // 表示名では動かない (起動時に ID で解決されるため)。
       dmPolicy: 'allowlist',
-      allowFrom: [],
+      allowFrom: [
+        'U04SR9CPRLH',
+        'U04SCL3E1J6',
+      ],
 
       // チャンネルも許可制。メンションされた時だけ反応する。
       //

--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -132,6 +132,7 @@
       // 表示名では動かない (起動時に ID で解決されるため)。
       dmPolicy: 'allowlist',
       allowFrom: [
+        'U04S9MVCN21', // morihaya
         'U04SR9CPRLH',
         'U04SCL3E1J6',
       ],


### PR DESCRIPTION
## 概要

`allowFrom` が空だと `dmPolicy: allowlist` の下で**全 DM が破棄される**。家族 2 名のユーザ ID を設定する。

```
channels.slack.allowFrom is empty; all DMs will be dropped.
```

## 併せて確認したこと

**Bedrock の use case details が提出され、#94 で残件だったエラーが解消した。**

```
直近10分のエラー: 0 件
agent model: amazon-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0
```

実際の応答も primary の Haiku 4.5 から返っている(以前は `ResourceNotFoundException` で全滅していた)。日本時間も正しく反映されている。

```
$ openclaw agent --agent main -m "こんばんは。あなたの役割を1文で教えてください。"
こんばんは。現在の日時は 2026年8月1日 00:51 (JST) です。
私の役割は、あなたの日常のタスクをサポートし、情報を提供し、
ファイルや作業を管理するアシスタントです。
```

## 状態

| 項目 | 状態 |
|---|---|
| Gateway | healthy |
| Bedrock (Haiku 4.5 / jp プロファイル) | 疎通 OK |
| Slack Socket Mode | connected |
| DM 許可リスト | 本 PR で設定 |

これで Slack から DM して会話できる状態になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)