### PR TITLE
fix(openclaw): Slack の ID とチャンネル設定をリポジトリから外す

### DIFF
--- a/docker/openclaw/README.md
+++ b/docker/openclaw/README.md
@@ -36,6 +36,15 @@ VM そのものは Terraform 管理 ([terraform/homelab/106vm_openclaw.tf](../..
 scp compose.yaml morihaya@192.168.1.12:~/openclaw/
 ```
 
+> [!CAUTION]
+> **`openclaw.json` をそのまま scp してはいけない。**
+> このリポジトリは Public のため、`channels.slack` の `allowFrom` と
+> `channels` は**意図的に空にしてある**。実際のユーザー ID / チャンネル ID は
+> VM 上のファイルにだけ存在する。上書きすると Bot が誰にも反応しなくなる。
+>
+> 配布する場合は、VM 側の該当ブロックを退避してから差し替えるか、
+> 変更箇所だけを手で反映すること。
+
 ```bash
 scp openclaw.json morihaya@192.168.1.12:~/openclaw/data/config/
 ```

--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -127,22 +127,33 @@
       appToken: { source: 'env', provider: 'default', id: 'SLACK_APP_TOKEN' },
       botToken: { source: 'env', provider: 'default', id: 'SLACK_BOT_TOKEN' },
 
+      // ---------------------------------------------------------------------
+      // 【重要】ここから下の実際の値はこのリポジトリで管理しない。
+      //
+      // このリポジトリは Public。Slack のユーザー ID とチャンネル ID 自体は
+      // 認証情報ではないが、チャンネル名からは家庭の内情が読み取れてしまう。
+      // 実際の値は VM 106 の ~/openclaw/data/config/openclaw.json にだけ置く。
+      //
+      // そのため **このファイルを VM へそのまま scp してはいけない。**
+      // 配布する場合は下の 2 ブロックを VM 側の値で上書きしてから行うこと。
+      // ---------------------------------------------------------------------
+
       // DM は家族のみに限定する。空にすると全 DM が破棄される。
       // ID は Slack のプロフィール > その他 > メンバー ID からコピーする。
       // 表示名では動かない (起動時に ID で解決されるため)。
       dmPolicy: 'allowlist',
       allowFrom: [
-        'U04S9MVCN21', // morihaya
-        'U04SR9CPRLH',
-        'U04SCL3E1J6',
+        // 'U0123456789', // VM 側で設定
       ],
 
-      // チャンネルも許可制。メンションされた時だけ反応する。
+      // チャンネルも許可制。requireMention を false にすると当該チャンネルの
+      // 全発言に反応し、Bedrock の課金が会話量にそのまま比例する。
       //
-      // TODO: 常駐させたいチャンネル ID (C で始まる) を入れる。
+      // NOTE: 許可しても Bot が参加していないチャンネルからはイベントが
+      // 届かない。使いたいチャンネルでは Slack 側で /invite が要る。
       groupPolicy: 'allowlist',
       channels: {
-        // 'C0123456789': { requireMention: true },
+        // 'C0123456789': { requireMention: true }, // VM 側で設定
       },
     },
   },


### PR DESCRIPTION
## 概要

**このリポジトリは Public。** Slack のチャンネル名 (`family-meeting`, `team-haruhhkko` など) からは家庭の内情が読み取れてしまうため、Slack の ID 系設定をリポジトリ管理から外す。

ID 自体は認証情報ではないが、公開する必要も無い。

## 変更内容

- `channels.slack.allowFrom` と `channels.slack.channels` を空にし、実際の値は **VM 106 上のファイルにだけ**置く
- この結果 `openclaw.json` は**そのまま scp できなくなる**ため、README に注意書きを追加。上書きすると Bot が誰にも反応しなくなる

## 関連する対応

- 全 18 チャンネルを名前付きで登録しようとしていた #96 は**取り下げ済み**
- VM 側の設定は変更なし(実際の値が入ったまま稼働中)

## 未対応: main の履歴

`main` の履歴には既に Slack ユーザー ID 3 件が含まれている(#95 でマージ済み)。完全に消すには履歴の書き換えが要るため、取り扱いは別途判断とする。

- ID は認証情報ではなく、これ単体で何かにアクセスできるものではない
- 消す場合は `git filter-repo` 等での書き換え + force-push が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)