### PR TITLE
feat(aws): blog.morihaya.tech の Route 53 レコードを Terraform 管理下に取り込む

### DIFF
--- a/terraform/aws/common-r53/imports.tf
+++ b/terraform/aws/common-r53/imports.tf
@@ -1,0 +1,8 @@
+# 既存の Route 53 レコードを Terraform 管理下に取り込むための import ブロック。
+# HCP Terraform 上の apply が完了したら、このファイルは削除して構わない。
+
+# blog.morihaya.tech (CNAME -> hatenablog.com)
+import {
+  to = module.records["blog"].aws_route53_record.this
+  id = "${data.aws_route53_zone.morihaya_tech.zone_id}_blog.morihaya.tech_CNAME"
+}

--- a/terraform/aws/common-r53/r53.tf
+++ b/terraform/aws/common-r53/r53.tf
@@ -19,6 +19,12 @@ locals {
       ttl     = 299
       records = ["140.238.51.204"]
     }
+    blog = {
+      name    = "blog.morihaya.tech"
+      type    = "CNAME"
+      ttl     = 3600
+      records = ["hatenablog.com"] # はてなブログ独自ドメイン
+    }
   }
 }
 


### PR DESCRIPTION
## 概要

手動作成のまま残っていた `blog.morihaya.tech` (はてなブログ独自ドメイン用の CNAME) を、`terraform/aws/common-r53` の管理下に取り込みます。

## 変更内容

- `r53.tf`: `local.records` に `blog` を追加 (`CNAME` / TTL 3600 / `hatenablog.com`)
- `imports.tf` (新規): `module.records["blog"].aws_route53_record.this` への import ブロック

ローカルに AWS 認証情報がなく state も HCP Terraform 側にあるため、`terraform import` CLI ではなく import ブロックを置いて TFC の run に取り込みを行わせます。

## レビュー時の確認ポイント

1. **plan が `1 to import, 0 to add, 0 to change, 0 to destroy` になっていること。**
   `records` に in-place change が出る場合、Route 53 側の値が末尾ドット付き (`hatenablog.com.`) で保存されています。その場合は config を `["hatenablog.com."]` に修正してください。レコードの実値は権威 DNS (`ns-64.awsdns-08.com`) への dig で確認しましたが、dig は保存形式に関わらず正規形 (末尾ドット付き) を返すため、API 上の保存形式までは判別できていません。
2. **apply 完了後に `imports.tf` を削除すること。** import ブロックは一度きりの動作で、以降は残しておいても意味がありません。

`terraform fmt` / `terraform validate` は通過済みです (plan はローカルの HCP 認証情報が別アカウントのため未実行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)