### PR TITLE
fix(openclaw): カレンダー MCP の HTTP モードを動くようにする

### DIFF
--- a/docker/openclaw/README.md
+++ b/docker/openclaw/README.md
@@ -193,6 +193,14 @@ OAuth トークンを置くとエージェント自身 (= プロンプトイン�
    > 現在は Android 開発用アカウント (カレンダー未使用) を流用している。
 2. 自分と家族のカレンダーを、そのアカウントへ
    **「予定の表示 (すべての予定の詳細)」** で共有する。「変更権限」にはしない
+
+   > [!IMPORTANT]
+   > **共有しただけでは API から見えない。受け取り側での「追加」が要る。**
+   > Google は共有時に招待メールを送り、そのリンクを踏んで追加して初めて
+   > `calendarList` に載る。共有した側の画面では完了して見えるので気づきにくい。
+   >
+   > 見えているかは `list-calendars` で確認する。執事自身の primary と
+   > 「日本の祝日」しか出てこないなら、まだ追加されていない。
 3. **GCP プロジェクトは新規に作り**、**Google Calendar API を有効化**する
 
    > [!IMPORTANT]
@@ -294,6 +302,14 @@ docker compose exec openclaw openclaw mcp status --verbose
 
 ### 落とし穴
 
+- **上流の HTTP モードは素のままでは動かない。** transport を全リクエストで使い回して
+  いるため、コンテナ起動後の 1 回目の POST しか通らない。2 回目以降は本文なしの 500 に
+  なり、しかもサーバは起動して `/health` も 200 を返し続けるので気づきにくい。
+  [patch-http-transport.js](google-calendar-mcp/patch-http-transport.js) で回避している
+- **`ENABLED_TOOLS` は `manage-accounts` を止められない。** サーバは指定外のこのツールも
+  公開してくる (サーバ生では 8 個、`ENABLED_TOOLS` は 7 個)。止めているのは
+  `openclaw.json` の `toolFilter.include` のほう。**二重の網が実際に効いている箇所**なので、
+  どちらか一方に減らさないこと
 - **エンドポイントのパスを `/` にしない。** このサーバは `GET /` をアカウント管理 UI に
   横取りしており、streamable-http の SSE ストリームと衝突する。`/mcp` を使う
   (既知ルート以外は MCP トランスポートへフォールスルーする)

--- a/docker/openclaw/google-calendar-mcp/Dockerfile
+++ b/docker/openclaw/google-calendar-mcp/Dockerfile
@@ -16,6 +16,12 @@ ARG GCAL_MCP_VERSION=2.6.2
 RUN npm install -g "@cocal/google-calendar-mcp@${GCAL_MCP_VERSION}" \
     && npm cache clean --force
 
+# 上流の HTTP モードは transport を全リクエストで使い回しており、コンテナ起動後
+# 1回目の POST しか通らない。パッチの詳細と、更新時にどう判断するかはスクリプト
+# 冒頭のコメントを参照。アンカーが見つからなければ build はここで失敗する。
+COPY patch-http-transport.js /tmp/patch-http-transport.js
+RUN node /tmp/patch-http-transport.js && rm /tmp/patch-http-transport.js
+
 # トークンの置き場。compose 側でホストのディレクトリを載せる。
 # node ユーザ (uid 1000) が書き込むので所有者を合わせておく。
 RUN install -d -o node -g node /data

--- a/docker/openclaw/google-calendar-mcp/patch-http-transport.js
+++ b/docker/openclaw/google-calendar-mcp/patch-http-transport.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+//
+// 上流バグの回避パッチ (@cocal/google-calendar-mcp の HTTP モード)
+//
+// ■ 症状
+//   コンテナ起動後、MCP の POST は **1 回目だけ成功し、2 回目以降は必ず
+//   HTTP 500 (本文なし)** になる。気づきにくい壊れ方をする:
+//     - サーバは正常に起動し、トークンも読める
+//     - /health は 200 を返し続けるので healthcheck は緑のまま
+//     - アプリ側の catch が発火しないため、ログには何も出ない
+//   OpenClaw からは "Streamable HTTP error: Error POSTing to endpoint:" と
+//   だけ見える。initialize の次の tools/list で落ちるので、事実上使えない。
+//
+// ■ 原因
+//   上流の src/transports/http.ts は connect() の中で
+//   StreamableHTTPServerTransport を 1 個だけ生成し、全リクエストで
+//   使い回している。MCP SDK はステートレスモード (sessionIdGenerator:
+//   undefined) では **リクエストごとに新しい transport** を要求するため、
+//   2 回目以降が SDK の内部で落ちる。
+//
+// ■ 対処
+//   ディスパッチ箇所を、リクエストごとに transport を生成して繋ぐ形に
+//   書き換える。透過的な差し替えなので上流の他の挙動には触れない。
+//
+//   ただし SDK は「1 つの Protocol に 1 つの transport」を強制しており、
+//   閉じずに繋ぎ直すと次で弾かれる:
+//
+//     Already connected to a transport. Call close() before connecting to a
+//     new transport, or use a separate Protocol instance per connection.
+//
+//   そのため **前の transport を閉じてから** 新しいものを繋ぐ。
+//
+//   ■ 制約: 逐次リクエストを前提にしている
+//     並行リクエストが来ると、後発が先発の transport を閉じてしまう。
+//     この用途 (OpenClaw 1 クライアントからの逐次呼び出し) では問題ない。
+//     複数クライアントから同時に叩く構成にする場合はこの方式を見直すこと。
+//     本来は上流が「リクエストごとに Server ごと作る」のが正しい。
+//
+// ■ 更新時の注意
+//   アンカーが見つからなければ **build を失敗させる**。上流が直したり
+//   構造を変えたりしたときに、パッチが黙って無効化されるのを防ぐため。
+//   その場合はまず上流の修正状況を確認すること (直っていればこのファイルと
+//   Dockerfile の COPY/RUN ごと削除できる)。
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim();
+const target = path.join(globalRoot, '@cocal/google-calendar-mcp/build/index.js');
+
+if (!fs.existsSync(target)) {
+  console.error(`[patch] バンドルが見つからない: ${target}`);
+  process.exit(1);
+}
+
+const source = fs.readFileSync(target, 'utf8');
+
+// 単一の共有 transport を使っているディスパッチ箇所。
+const anchor = /^([ \t]*)await transport\.handleRequest\(req, res\);[ \t]*$/gm;
+const hits = source.match(anchor);
+
+if (!hits) {
+  console.error('[patch] アンカーが見つからない。上流の構造が変わった可能性がある。');
+  console.error('[patch] 上流の修正状況を確認すること。直っていればこのパッチは不要。');
+  process.exit(1);
+}
+if (hits.length !== 1) {
+  console.error(`[patch] アンカーが一意でない (${hits.length} 箇所)。手で確認すること。`);
+  process.exit(1);
+}
+
+// 念のため、パッチ対象の前提 (単一 transport の生成) が実在することも確かめる。
+if (!source.includes('new StreamableHTTPServerTransport({')) {
+  console.error('[patch] StreamableHTTPServerTransport の生成箇所が見つからない。');
+  process.exit(1);
+}
+
+const patched = source.replace(anchor, (_match, indent) =>
+  [
+    `${indent}// [morihaya-infra] リクエストごとに transport を作り直す (上流バグ回避)`,
+    `${indent}// SDK は 1 Protocol に 1 transport しか許さないので、先に前のものを閉じる。`,
+    `${indent}const previousTransport = this.__perRequestTransport ?? transport;`,
+    `${indent}try {`,
+    `${indent}  await previousTransport.close();`,
+    `${indent}} catch {}`,
+    `${indent}const perRequestTransport = new StreamableHTTPServerTransport({`,
+    `${indent}  sessionIdGenerator: void 0`,
+    `${indent}});`,
+    `${indent}this.__perRequestTransport = perRequestTransport;`,
+    `${indent}await this.server.connect(perRequestTransport);`,
+    `${indent}await perRequestTransport.handleRequest(req, res);`,
+  ].join('\n'),
+);
+
+fs.writeFileSync(target, patched);
+console.log(`[patch] 適用した: ${target}`);


### PR DESCRIPTION
#107 で入れたカレンダー連携を実機に載せたところ、**素のままでは動かなかった**。その修正と、実機で分かったことの記録。

## 何が起きていたか

上流 `@cocal/google-calendar-mcp@2.6.2` の HTTP モードは、`connect()` で `StreamableHTTPServerTransport` を **1 個だけ生成して全リクエストで使い回している**。MCP SDK はステートレスモードではリクエストごとの transport を要求するため、**コンテナ起動後の 1 回目の POST しか通らない。**

壊れ方が分かりにくい。

- サーバは正常に起動し、トークンも読める
- `/health` は 200 を返し続けるので healthcheck は緑のまま
- アプリ側の catch が発火せず、サーバログには何も出ない
- OpenClaw からは `Error POSTing to endpoint:` としか見えない (initialize の次の tools/list で落ちる)

切り分けの決め手はこれ。

```
POST #1 -> HTTP 200
POST #2 -> HTTP 500
POST #3 -> HTTP 500
```

## 修正

`patch-http-transport.js` を追加し、ビルド時にバンドルのディスパッチ箇所を書き換える。リクエストごとに transport を作り直す。SDK は 1 Protocol に 1 transport しか許さない (`Already connected to a transport`) ので、前のものを閉じてから繋ぐ。

- 逐次リクエスト前提であることをスクリプトに明記した (この用途では OpenClaw 1 クライアントのみ)
- **アンカーが見つからなければ build を失敗させる。** 上流が直したり構造を変えたときに、パッチが黙って無効化されるのを防ぐため
- パッケージはバージョン固定済みなので、勝手に壊れることはない

適用後:

```
POST #1..#4 -> すべて HTTP 200
openclaw mcp probe google-calendar
  -> google-calendar: 7 tools, resources, prompts
```

## 実機で分かった 2 点 (README に追記)

**`ENABLED_TOOLS` は `manage-accounts` を止められない。** サーバは指定外のこのツールも公開してくる (サーバ生 8 個 / 指定 7 個)。実際に止めていたのは `openclaw.json` の `toolFilter.include` のほうだった。**二重の網が本当に効いていた箇所**なので、どちらか一方に減らさないこと。

**カレンダーは共有しただけでは API に見えない。** 受け取り側が招待メールから追加して初めて `calendarList` に載る。共有した側の画面では完了して見えるので気づきにくい。

## 状態

OAuth 認可済み、MCP は OpenClaw から 7 ツールで認識済み。**残るはカレンダーの共有受け入れのみ** — 現状 `list-calendars` には執事自身の primary と「日本の祝日」しか出ていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)