### PR TITLE
feat(mac): デフォルトブラウザ切り替えの仕組みを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ This repository contains infrastructure definitions for managing multiple cloud 
 │   ├── spotify/        # Spotify playlist management
 │   └── tailscale/      # Tailscale VPN ACLs and DNS
 │
-└── ansible/            # Configuration Management
-    ├── inventories/    # Host definitions (plaintext; see ansible/README.md)
-    └── roles/          # Reusable roles (common)
+├── ansible/            # Configuration Management
+│   ├── inventories/    # Host definitions (plaintext; see ansible/README.md)
+│   └── roles/          # Reusable roles (common)
+│
+└── mac/                # Local workstation setup
+    └── default-browser/  # One-key default browser switching (Finicky + Raycast)
 ```
 
 ## 🛠️ Terraform Configurations

--- a/mac/default-browser/README.md
+++ b/mac/default-browser/README.md
@@ -1,0 +1,165 @@
+# macOS デフォルトブラウザ切り替え
+
+仕事では Edge、個人作業では Comet や Chrome、というようにリンクの開き先を
+ワンアクションで切り替えるための仕組み。Raycast のコマンドかシェルから叩く。
+
+- 構築: 2026-08-14
+- 検証環境: macOS 15.7.7 (Sequoia, Apple Silicon) / Finicky 4.2.2 / Raycast 1.104.24
+
+## 構成
+
+```
+mac/default-browser/
+├── bin/set-default-browser   # 本体
+├── raycast/                  # Raycast スクリプトコマンド 5 個
+├── finicky.js.example        # Finicky 設定の雛形
+└── install.sh                # 新しいマシンへの導入
+```
+
+実際に使うファイルの配置先は次のとおり。`install.sh` がこのリポジトリへの
+シンボリックリンクを張るので、編集は Git で追跡される。
+
+| 配置先 | 内容 |
+|---|---|
+| `~/.local/bin/set-default-browser` | 本体へのシンボリックリンク |
+| `~/.config/raycast/scripts/` | Raycast コマンドへのシンボリックリンク |
+| `~/.finicky.js` | 雛形からコピー。**追跡しない** |
+
+`~/.finicky.js` を追跡しないのは、社内ドメインの振り分けルールを書いたときに
+公開リポジトリへ流れないようにするため。
+
+## 仕組み
+
+macOS のデフォルトブラウザは **Finicky に固定**する。Finicky が全リンクを受け取り、
+`~/.finicky.js` の `DEFAULT_BROWSER` に書かれたブラウザへ転送する。切り替えとは
+この 1 行の書き換えのことで、OS の設定自体は一度も変更しない。
+
+```
+リンククリック → Finicky → DEFAULT_BROWSER のブラウザ
+```
+
+この構成にした理由は「なぜ OS の設定を直接変えないか」の節を参照。
+
+## 導入
+
+```sh
+./install.sh
+```
+
+そのあと手動で 3 つ。スクリプト化できない。
+
+1. Finicky のメニューバーアイコン → Set as default browser → macOS の確認ダイアログを承認
+2. Finicky の設定で **Start at login** を有効化（起動していないと転送されない）
+3. Raycast → Settings → Extensions → Script Commands → Add Script Directory で
+   `~/.config/raycast/scripts` を追加
+
+確認:
+
+```sh
+set-default-browser --check
+```
+
+## 使い方
+
+```sh
+set-default-browser            # 今どれか表示
+set-default-browser comet      # Comet に切り替え
+set-default-browser toggle     # 仕事用 ⇄ 個人用
+set-default-browser --check    # 導入状態の検証
+```
+
+対応: `edge` / `comet` / `chrome` / `safari` / `firefox` / `brave` / `toggle`
+
+`toggle` の対象は環境変数 `WORK_BROWSER` と `PERSONAL_BROWSER` で変えられる。
+既定は `edge` と `comet`。
+
+Raycast 側は 5 コマンド。トグルにホットキーを割り当てるのが一番速い。
+
+| コマンド | 動作 |
+|---|---|
+| Default Browser: Toggle Work/Personal | Edge ⇄ Comet |
+| Default Browser: Edge / Comet / Chrome | 直接指定 |
+| Default Browser: Show | 現在の設定を表示 |
+
+## ドメイン単位のルール
+
+`~/.finicky.js` の `handlers` に書く。個人モード中でも仕事のリンクだけ Edge に
+固定する、といった使い方ができる。`handlers` は `DEFAULT_BROWSER` より優先される。
+
+```js
+handlers: [
+  {
+    match: ["teams.microsoft.com/*", "*.sharepoint.com/*"],
+    browser: "Microsoft Edge",
+  },
+],
+```
+
+手で編集した場合は Finicky の再起動が必要（後述）。
+
+## なぜ OS の設定を直接変えないか
+
+最初は [defaultbrowser](https://github.com/kerma/defaultbrowser) で OS のデフォルトを
+直接切り替える実装にしたが、実用にならなかった。以下は実機で確認した内容で、
+どれも既存のドキュメントには書かれていない。
+
+### 1. macOS 15 は切り替えのたびに確認ダイアログを出す
+
+Apple の仕様で、`defaultbrowser` でも `duti` でも回避できない。自動で押すには
+System Events による UI スクリプティングが必要で、呼び出し元アプリに
+**アクセシビリティとオートメーションの両方**の権限が要る。
+
+ターミナルにアクセシビリティ権限を与えるのは「そのアプリが他のあらゆるアプリを
+操作できる」ということなので、業務用マシンでは割に合わない。加えて
+`CoreServicesUIAgent` がダイアログを出すまでの時間が不定で、ポーリングが
+空振りすることもあった。
+
+### 2. `defaultbrowser` は現在値を誤って報告する
+
+書き込み時に Bundle ID を小文字化するのに、現在値の照合では大文字小文字を
+区別する。LaunchServices 自体は区別しないので**切り替えは成功するが、
+ツールは自分が書いた値を認識できず `*` を表示しない**。
+
+影響を受けるのは Bundle ID に大文字を含むブラウザだけ。
+
+| ブラウザ | Bundle ID | 症状 |
+|---|---|---|
+| Microsoft Edge | `com.microsoft.edgemac` | 正常 |
+| Comet | `ai.perplexity.comet` | 正常 |
+| Firefox | `org.mozilla.firefox` | 正常 |
+| Google Chrome | `com.google.Chrome` | **報告できない** |
+| Safari | `com.apple.Safari` | **報告できない** |
+| Brave | `com.brave.Browser` | **報告できない** |
+
+このため「切り替えは成功しているのに失敗と報告される」という紛らわしい状態になる。
+現在値を知りたいなら LaunchServices の plist を直接読むほうが確実。
+
+```sh
+python3 -c 'import plistlib,os
+d=plistlib.load(open(os.path.expanduser("~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"),"rb"))
+print([h.get("LSHandlerRoleAll") for h in d["LSHandlers"] if h.get("LSHandlerURLScheme")=="https"])'
+```
+
+### 3. Finicky 4.2.2 は設定をホットリロードしない
+
+README には設定変更で自動的にリロードされるとあるが、実際にはされない。
+未起動のブラウザを指定して「実際に起動するか」で判定したところ、
+
+- `sed -i` による書き換え（inode が変わる）→ リロードされない
+- inode を保つ書き換え → **やはりリロードされない**
+- Finicky を再起動 → 反映される
+
+このため `set-default-browser` は書き換え後に Finicky を再起動する。
+バックグラウンドエージェント（`LSUIElement`）なので画面上は何も起きず、
+切り替え全体で 0.7 秒ほど。
+
+**手で `~/.finicky.js` を編集したときも再起動が必要。**
+
+```sh
+pkill -x Finicky && open -gj -a Finicky
+```
+
+## 権限について
+
+この構成ではアクセシビリティもオートメーションも**不要**。確認ダイアログが出るのは
+Finicky を既定に設定する最初の 1 回だけ。

--- a/mac/default-browser/bin/set-default-browser
+++ b/mac/default-browser/bin/set-default-browser
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Switch which browser opens links, via Finicky.
+#
+#   set-default-browser            # show the current browser
+#   set-default-browser edge       # route links to Microsoft Edge
+#   set-default-browser comet      # route links to Comet
+#   set-default-browser toggle     # flip between work and personal
+#
+# Finicky must be set as the macOS default browser once (see --check). After
+# that, switching is just a config rewrite: no confirmation dialog, and no
+# Accessibility or Automation permission needed.
+set -euo pipefail
+
+CONFIG="${FINICKY_CONFIG:-$HOME/.finicky.js}"
+MARKER="finicky-managed"
+FINICKY_BUNDLE="se.johnste.finicky"
+LS_PLIST="$HOME/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+
+WORK_BROWSER="${WORK_BROWSER:-edge}"
+PERSONAL_BROWSER="${PERSONAL_BROWSER:-comet}"
+
+# friendly name -> macOS application name (what Finicky expects)
+resolve() {
+  case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
+    edge | msedge | edgemac) echo "Microsoft Edge" ;;
+    comet) echo "Comet" ;;
+    chrome | googlechrome) echo "Google Chrome" ;;
+    safari) echo "Safari" ;;
+    firefox | ff) echo "Firefox" ;;
+    brave) echo "Brave Browser" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Browser currently written into the Finicky config.
+current() {
+  grep -- "$MARKER" "$CONFIG" 2>/dev/null | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1
+}
+
+# macOS https handler, lowercased. Empty if unset.
+os_handler() {
+  python3 - "$LS_PLIST" <<'PY' 2>/dev/null || true
+import plistlib, sys
+try:
+    with open(sys.argv[1], "rb") as f:
+        d = plistlib.load(f)
+except Exception:
+    raise SystemExit
+for h in d.get("LSHandlers", []):
+    if h.get("LSHandlerURLScheme") == "https":
+        v = h.get("LSHandlerRoleAll") or ""
+        if v and v != "-":
+            print(v.lower())
+        break
+PY
+}
+
+check_setup() {
+  local ok=0
+  if [ ! -f "$CONFIG" ]; then
+    echo "Missing config: $CONFIG" >&2
+    ok=1
+  fi
+  if [ ! -d /Applications/Finicky.app ]; then
+    echo "Finicky is not installed (brew install --cask finicky)." >&2
+    ok=1
+  fi
+  if [ "$(os_handler)" != "$FINICKY_BUNDLE" ]; then
+    echo "Finicky is not the macOS default browser." >&2
+    echo "Fix: open Finicky, click 'Set as default browser', confirm the dialog once." >&2
+    ok=1
+  fi
+  if ! pgrep -qx Finicky; then
+    echo "Finicky is not running (links will not be routed)." >&2
+    echo "Fix: open -a Finicky, and add it to Login Items." >&2
+    ok=1
+  fi
+  return $ok
+}
+
+if [ "${1:-}" = "--check" ]; then
+  if check_setup; then
+    echo "Setup OK. Links route through Finicky to $(current)."
+  else
+    exit 1
+  fi
+  exit 0
+fi
+
+if [ $# -eq 0 ]; then
+  cur="$(current)"
+  [ -n "$cur" ] && echo "$cur" || { echo "Could not read $CONFIG" >&2; exit 1; }
+  exit 0
+fi
+
+want="$1"
+if [ "$want" = "toggle" ]; then
+  if [ "$(current)" = "$(resolve "$WORK_BROWSER")" ]; then
+    want="$PERSONAL_BROWSER"
+  else
+    want="$WORK_BROWSER"
+  fi
+fi
+
+app="$(resolve "$want")" || {
+  echo "Unknown browser: $want (edge|comet|chrome|safari|firefox|brave|toggle)" >&2
+  exit 1
+}
+
+if [ ! -d "/Applications/$app.app" ]; then
+  echo "Not installed: /Applications/$app.app" >&2
+  exit 1
+fi
+
+if ! grep -q -- "$MARKER" "$CONFIG" 2>/dev/null; then
+  echo "No line marked '$MARKER' in $CONFIG -- cannot switch safely." >&2
+  exit 1
+fi
+
+if [ "$(current)" = "$app" ]; then
+  echo "Already $app"
+  exit 0
+fi
+
+# Rewrite the quoted app name on the managed line only.
+sed -i '' "/$MARKER/s/\"[^\"]*\"/\"$app\"/" "$CONFIG"
+
+now="$(current)"
+if [ "$now" != "$app" ]; then
+  echo "Failed to update $CONFIG (still $now)." >&2
+  exit 1
+fi
+
+# Finicky 4.2.2 does not hot-reload its config -- neither a rename-style write
+# (sed -i) nor an inode-preserving one triggers a reload. Restarting it is what
+# actually applies the change. It is a background agent, so this is invisible.
+reload_finicky() {
+  pgrep -qx Finicky || return 0
+  pkill -x Finicky || true
+  for _ in $(seq 1 20); do
+    pgrep -qx Finicky || break
+    sleep 0.1
+  done
+  open -gj -a Finicky 2>/dev/null || open -a Finicky
+  for _ in $(seq 1 30); do
+    pgrep -qx Finicky && return 0
+    sleep 0.1
+  done
+  echo "Warning: Finicky did not come back up; run 'open -a Finicky'." >&2
+}
+reload_finicky >/dev/null
+
+echo "Links now open in $app"
+
+# Non-fatal warnings, so the switch still reports success while telling the
+# user why it might not take effect yet.
+check_setup || true

--- a/mac/default-browser/finicky.js.example
+++ b/mac/default-browser/finicky.js.example
@@ -1,0 +1,27 @@
+// Finicky config -- routes every opened link to a browser.
+//
+// Template: copy to ~/.finicky.js. The live file is deliberately not tracked in
+// this repository, so machine-specific routing rules stay off GitHub.
+//
+// The DEFAULT_BROWSER line below is rewritten by `set-default-browser`.
+// Keep the `finicky-managed` marker comment on it -- the script matches on it.
+//
+// Finicky 4.2.2 does NOT hot-reload this file, so `set-default-browser` restarts
+// Finicky after every edit. If you edit this file by hand, restart Finicky
+// yourself or the change will not take effect.
+
+const DEFAULT_BROWSER = "Microsoft Edge"; // finicky-managed
+
+export default {
+  defaultBrowser: DEFAULT_BROWSER,
+
+  handlers: [
+    // Rules win over DEFAULT_BROWSER, so put links here that should always
+    // open in one specific browser no matter which mode you are in.
+    //
+    // {
+    //   match: ["teams.microsoft.com/*", "*.sharepoint.com/*"],
+    //   browser: "Microsoft Edge",
+    // },
+  ],
+};

--- a/mac/default-browser/install.sh
+++ b/mac/default-browser/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Set up the default-browser switcher on a fresh Mac.
+#
+#   ./install.sh
+#
+# Symlinks the script and the Raycast commands back into this repository, so
+# edits stay tracked. The Finicky config is copied (not linked) because it is
+# machine-local and deliberately untracked.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$HOME/.local/bin"
+RAYCAST_DIR="$HOME/.config/raycast/scripts"
+FINICKY_CONFIG="$HOME/.finicky.js"
+
+echo "==> Installing from $REPO_DIR"
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required: https://brew.sh" >&2
+  exit 1
+fi
+
+if [ ! -d /Applications/Finicky.app ]; then
+  echo "==> Installing Finicky"
+  brew install --cask finicky
+else
+  echo "==> Finicky already installed"
+fi
+
+echo "==> Linking set-default-browser into $BIN_DIR"
+mkdir -p "$BIN_DIR"
+ln -sfn "$REPO_DIR/bin/set-default-browser" "$BIN_DIR/set-default-browser"
+
+echo "==> Linking Raycast script commands into $RAYCAST_DIR"
+mkdir -p "$RAYCAST_DIR"
+for f in "$REPO_DIR"/raycast/*.sh; do
+  ln -sfn "$f" "$RAYCAST_DIR/$(basename "$f")"
+done
+
+if [ -e "$FINICKY_CONFIG" ]; then
+  echo "==> $FINICKY_CONFIG already exists, leaving it alone"
+else
+  echo "==> Creating $FINICKY_CONFIG from template"
+  cp "$REPO_DIR/finicky.js.example" "$FINICKY_CONFIG"
+fi
+
+open -gj -a Finicky 2>/dev/null || open -a Finicky
+
+cat <<'EOF'
+
+==> Remaining manual steps (they cannot be scripted)
+
+  1. Finicky menu bar icon > Set as default browser, then confirm the macOS
+     dialog. This is the only confirmation dialog you will ever see.
+  2. Finicky settings > enable "Start at login". Links are not routed while
+     Finicky is not running.
+  3. Raycast > Settings > Extensions > Script Commands > Add Script Directory
+     and select ~/.config/raycast/scripts
+
+Then verify:
+
+  set-default-browser --check
+EOF

--- a/mac/default-browser/raycast/default-browser-chrome.sh
+++ b/mac/default-browser/raycast/default-browser-chrome.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Default Browser: Chrome
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🌈
+# @raycast.packageName Default Browser
+
+# Documentation:
+# @raycast.description Set Google Chrome as the default browser
+# @raycast.author morihaya
+
+exec "$HOME/.local/bin/set-default-browser" chrome

--- a/mac/default-browser/raycast/default-browser-comet.sh
+++ b/mac/default-browser/raycast/default-browser-comet.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Default Browser: Comet
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon ☄️
+# @raycast.packageName Default Browser
+
+# Documentation:
+# @raycast.description Set Comet as the default browser (personal)
+# @raycast.author morihaya
+
+exec "$HOME/.local/bin/set-default-browser" comet

--- a/mac/default-browser/raycast/default-browser-edge.sh
+++ b/mac/default-browser/raycast/default-browser-edge.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Default Browser: Edge
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🏢
+# @raycast.packageName Default Browser
+
+# Documentation:
+# @raycast.description Set Microsoft Edge as the default browser (work)
+# @raycast.author morihaya
+
+exec "$HOME/.local/bin/set-default-browser" edge

--- a/mac/default-browser/raycast/default-browser-show.sh
+++ b/mac/default-browser/raycast/default-browser-show.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Default Browser: Show
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🔍
+# @raycast.packageName Default Browser
+
+# Documentation:
+# @raycast.description Show which browser is currently the default
+# @raycast.author morihaya
+
+exec "$HOME/.local/bin/set-default-browser" 

--- a/mac/default-browser/raycast/default-browser-toggle.sh
+++ b/mac/default-browser/raycast/default-browser-toggle.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Default Browser: Toggle Work/Personal
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🔄
+# @raycast.packageName Default Browser
+
+# Documentation:
+# @raycast.description Flip the default browser between Edge (work) and Comet (personal)
+# @raycast.author morihaya
+
+export WORK_BROWSER=edge
+export PERSONAL_BROWSER=comet
+
+exec "$HOME/.local/bin/set-default-browser" toggle


### PR DESCRIPTION
## 概要

仕事では Edge、個人作業では Comet や Chrome、というようにリンクの開き先をワンアクションで切り替える仕組みを追加する。Raycast のコマンドかシェルから使う。

Finicky を macOS の既定ブラウザに固定し、`~/.finicky.js` の 1 行を書き換えて転送先を変える方式。OS の既定ブラウザ自体は変更しないので、**確認ダイアログもアクセシビリティ/オートメーション権限も不要**。

## 変更内容

| ファイル | 内容 |
|---|---|
| `mac/default-browser/bin/set-default-browser` | 本体 |
| `mac/default-browser/raycast/*.sh` | Raycast スクリプトコマンド 5 個 |
| `mac/default-browser/finicky.js.example` | Finicky 設定の雛形 |
| `mac/default-browser/install.sh` | 新しいマシンへの導入 |
| `mac/default-browser/README.md` | 手順と実機検証で判明した事項 |
| `README.md` | Repository Structure に `mac/` を追記 |

`~/.finicky.js` は雛形のみコミットし、実ファイルは追跡しない。社内ドメインの振り分けルールを追加しても公開リポジトリへ流れないようにするため。

## 実機検証で判明した事項

当初は [defaultbrowser](https://github.com/kerma/defaultbrowser) で OS の既定を直接切り替える実装にしたが、以下により方式を変更した。いずれも既存のドキュメントには記載がない。

1. **macOS 15 は切り替えのたびに確認ダイアログを出す。** `defaultbrowser` でも `duti` でも回避できない。自動で押すには呼び出し元アプリにアクセシビリティとオートメーション両方の権限が必要で、業務用マシンでは割に合わない。
2. **`defaultbrowser` は現在値を誤って報告する。** Bundle ID を小文字化して書き込むのに照合では大文字小文字を区別するため、`com.google.Chrome` / `com.apple.Safari` / `com.brave.Browser` が既定のとき `*` を表示しない。切り替えは成功しているのに失敗と報告される。
3. **Finicky 4.2.2 は設定をホットリロードしない。** README の記述と異なる。`sed -i`（inode が変わる）でも inode を保つ書き込みでも反映されず、再起動が必要。このため本体は書き換え後に Finicky を再起動する。

## 動作確認

判定を曖昧にしないため、**未起動のブラウザ**を指定して実際に起動するかで確認した。

- Finicky が http/https のハンドラであること（`se.johnste.finicky`）
- 設定書き換え → Finicky 再起動 → URL を開くと Firefox が起動
- スクリプト経由でエンドツーエンド、Safari が起動
- Raycast コマンド 5 種すべて正常
- 切り替え所要時間 0.67 秒

`install.sh` は未実行。既存環境を壊さないよう、新規マシン導入時に使う想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
