### PR TITLE
feat(route53): morihaya.techをGitHub Pagesへ向ける

### DIFF
--- a/terraform/aws/common-r53/r53.tf
+++ b/terraform/aws/common-r53/r53.tf
@@ -10,6 +10,12 @@ locals {
         "185.199.111.153",
       ]
     }
+    www = {
+      name    = "www.morihaya.tech"
+      type    = "CNAME"
+      ttl     = 3600
+      records = ["morihaya.github.io"]
+    }
     gcp01 = {
       name    = "gcp01.morihaya.tech"
       records = ["34.169.244.99"]

--- a/terraform/aws/common-r53/r53.tf
+++ b/terraform/aws/common-r53/r53.tf
@@ -1,6 +1,15 @@
 # DNS records for morihaya.tech
 locals {
   records = {
+    apex = {
+      name = "morihaya.tech"
+      records = [
+        "185.199.108.153",
+        "185.199.109.153",
+        "185.199.110.153",
+        "185.199.111.153",
+      ]
+    }
     gcp01 = {
       name    = "gcp01.morihaya.tech"
       records = ["34.169.244.99"]


### PR DESCRIPTION
## 概要

GitHub Pagesで公開した `morihaya.tech` のapexドメインと `www` サブドメインをGitHub Pagesへ向けます。

## 変更内容

- `morihaya.tech` のAレコードにGitHub公式の4つのIPアドレスを設定
- `www.morihaya.tech` のCNAMEを `morihaya.github.io` に設定
- GitHub Pages側で設定済みのapexドメインへ `www` から自動リダイレクトできる構成に変更

## 出典

- [About custom domains and GitHub Pages](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages)
- [Managing a custom domain for your GitHub Pages site](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site)

## 検証

- `terraform fmt -check -diff terraform/aws/common-r53/r53.tf`
- `terraform -chdir=terraform/aws/common-r53 validate`
